### PR TITLE
Fix and Refactor History

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ set(LIB_SOURCES
   alias.c
   bg_jobs.c
   builtins.c
+  circular_queue.c
   history.c
   linked_list.c
   job.c
@@ -20,6 +21,7 @@ set(HEADERS
   alias.h
   bg_jobs.h
   builtins.h
+  circular_queue.h
   dbg.h
   history.h
   linked_list.h

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -193,7 +193,7 @@ static void
 history_wrapper(const int argc, char** argv)
 {
   if (argc == 1) {
-    history_print(history_length);
+    history_print_all();
   } else if (argc == 2) {
     const long n_last_entries = strtol(argv[1], NULL, 10 /*base*/);
     if (n_last_entries < 0) {

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -195,15 +195,21 @@ history_wrapper(const int argc, char** argv)
   if (argc == 1) {
     history_print(history_length);
   } else if (argc == 2) {
-    const int num = atoi(argv[1]);
-    history_print(num);
-  } else {
-    if (strncmp(argv[1], "-s", strlen("-s")) == 0) {
-      const int hist_sz = atoi(argv[2]);
-      history_stifle(hist_sz);
-    } else {
-      help(HISTORY);
+    const long n_last_entries = strtol(argv[1], NULL, 10 /*base*/);
+    if (n_last_entries < 0) {
+      fprintf(stderr, "-bsh: history: %ld: invalid option\n", n_last_entries);
+      return;
     }
+
+    history_print(n_last_entries);
+   } else {
+    if (strncmp(argv[1], "-s", strlen("-s")) == 0) {
+      const long hist_capacity = strtol(argv[2], NULL, 10 /*base*/);
+      history_stifle(hist_capacity);
+      return;
+    }
+
+    help(HISTORY);
   }
 }
 

--- a/src/circular_queue.c
+++ b/src/circular_queue.c
@@ -27,15 +27,27 @@ circular_queue_init(const size_t capacity)
 }
 
 void
+circular_queue_free(circular_queue* queue)
+{
+  if (queue->entries) {
+    free(queue->entries);
+  }
+
+  free(queue);
+}
+
+void*
 circular_queue_push(circular_queue* const queue, void* elem)
 {
+  void* old = NULL;
   void** entry = &(queue->entries[queue->count % queue->capacity]);
   if (*entry) {
-    free(*entry);
+    old = *entry;
   }
 
   *entry = elem;
   queue->count++;
+  return old;
 }
 
 void*
@@ -65,20 +77,4 @@ circular_queue_set_capacity(circular_queue* queue, const size_t capacity)
 {
   UNUSED(queue);
   UNUSED(capacity);
-}
-
-void
-circular_queue_free(circular_queue* queue)
-{
-  if (queue->entries) {
-    for (size_t i = 0; i < queue->capacity; i++) {
-      if (queue->entries[i]) {
-        free(queue->entries[i]);
-      }
-    }
-
-    free(queue->entries);
-  }
-
-  free(queue);
 }

--- a/src/circular_queue.c
+++ b/src/circular_queue.c
@@ -1,0 +1,45 @@
+#include "circular_queue.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "util.h"
+
+circular_queue*
+circular_queue_init(size_t capacity)
+{
+  circular_queue* queue = malloc(sizeof(circular_queue));
+  queue->capacity = capacity;
+  queue->entries = calloc(capacity, MEMBER_SIZE(circular_queue, entries));
+  return queue;
+}
+
+void
+circular_queue_push(circular_queue* queue, void* elem)
+{
+  UNUSED(queue);
+  UNUSED(elem);
+}
+
+void
+circular_queue_set_capacity(circular_queue* queue, size_t capacity)
+{
+  UNUSED(queue);
+  UNUSED(capacity);
+}
+
+void
+circular_queue_free(circular_queue* queue)
+{
+  if (queue->entries) {
+    for (size_t i = 0; i < queue->capacity; i++) {
+      if (queue->entries[i]) {
+        free(queue->entries[i]);
+      }
+    }
+
+    free(queue->entries);
+  }
+
+  free(queue);
+}

--- a/src/circular_queue.c
+++ b/src/circular_queue.c
@@ -96,27 +96,18 @@ increase_capacity(circular_queue* queue, const size_t capacity)
 {
   assert(capacity > queue->capacity);
 
-  void** temp = malloc(capacity * MEMBER_SIZE(circular_queue, entries));
-  if (!temp) {
+  void** new_entries = calloc(capacity, MEMBER_SIZE(circular_queue, entries));
+  if (!new_entries) {
     return false;
   }
 
-  // zero-fill front to preserve circular_queue_get() ordering
-  const size_t pivot = queue->count % queue->capacity;
-  for (size_t i = 0; i < pivot; i++) {
-    temp[i] = NULL;
-  }
-
-  for (size_t i = pivot; i < queue->capacity; i++) {
-    temp[i] = queue->entries[i];
-  }
-
-  for (size_t i = 0, j = queue->capacity; i < pivot; i++, j++) {
-    temp[j] = queue->entries[i];
+  const size_t num_filled = min(queue->count, queue->capacity);
+  for (size_t pos = queue->count - num_filled; pos < queue->count; pos++) {
+    new_entries[pos % capacity] = queue->entries[pos % queue->capacity];
   }
 
   free(queue->entries);
-  queue->entries = temp;
+  queue->entries = new_entries;
   queue->capacity = capacity;
   return true;
 }

--- a/src/circular_queue.c
+++ b/src/circular_queue.c
@@ -1,28 +1,67 @@
 #include "circular_queue.h"
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "util.h"
 
 circular_queue*
-circular_queue_init(size_t capacity)
+circular_queue_init(const size_t capacity)
 {
+  assert(capacity > 0);
   circular_queue* queue = malloc(sizeof(circular_queue));
-  queue->capacity = capacity;
+  if (!queue) {
+    return NULL;
+  }
+
   queue->entries = calloc(capacity, MEMBER_SIZE(circular_queue, entries));
+  if (!queue->entries) {
+    free(queue);
+    return NULL;
+  }
+
+  queue->count = 0;
+  queue->capacity = capacity;
   return queue;
 }
 
 void
-circular_queue_push(circular_queue* queue, void* elem)
+circular_queue_push(circular_queue* const queue, void* elem)
 {
-  UNUSED(queue);
-  UNUSED(elem);
+  void** entry = &(queue->entries[queue->count % queue->capacity]);
+  if (*entry) {
+    free(*entry);
+  }
+
+  *entry = elem;
+  queue->count++;
+}
+
+void*
+circular_queue_get(const circular_queue* const queue, const size_t pos)
+{
+  if (pos > queue->count) {
+    return NULL;
+  }
+
+  // because size_t is unsigned and casting to int is dangerous, we can't simply
+  // do: (pos < (queue->count - queue->capacity))
+  if (queue->count < queue->capacity) {
+    if (pos > queue->count) {
+      return NULL;
+    }
+  } else {
+    if (pos < (queue->count - queue->capacity)) {
+      return NULL;
+    }
+  }
+
+  return queue->entries[pos % queue->capacity];
 }
 
 void
-circular_queue_set_capacity(circular_queue* queue, size_t capacity)
+circular_queue_set_capacity(circular_queue* queue, const size_t capacity)
 {
   UNUSED(queue);
   UNUSED(capacity);

--- a/src/circular_queue.c
+++ b/src/circular_queue.c
@@ -134,11 +134,11 @@ decrease_capacity(circular_queue* queue,
     return false;
   }
 
-  const size_t num_filled = (queue->count < queue->capacity) ? queue->count : queue->capacity;
-  const size_t num_excess_elems = (num_filled > capacity) ? num_filled - capacity : 0;
+  const size_t num_filled = min(queue->count, queue->capacity);
+  const size_t num_excess_elems = safe_sub(num_filled, capacity, 0);
   size_t old_pos = 0;
   if (num_excess_elems > 0) {
-    old_pos = queue->count - queue->capacity;
+    old_pos = safe_sub(queue->count, queue->capacity, 0);
     if (free_elem) {
       for (size_t i = 0; i < num_excess_elems; i++, old_pos++) {
         free_elem(queue->entries[old_pos % queue->capacity]);

--- a/src/circular_queue.h
+++ b/src/circular_queue.h
@@ -13,8 +13,8 @@
 typedef struct
 {
   void** entries;
-  size_t count;     /**< The total number of entries ever saved. */
-  size_t capacity;  /**< The number of entries allocated for. */
+  size_t count;    /**< The total number of entries ever saved. */
+  size_t capacity; /**< The number of entries allocated for. */
 } circular_queue;
 
 circular_queue* circular_queue_init(size_t capacity);
@@ -53,7 +53,7 @@ void circular_queue_free(circular_queue* queue);
  *  char* old = circular_queue_push(queue, strdup("elem2")));
  *  assert(old);
  *  free(old);
- *  
+ *
  *  for (size_t i = 0; i < queue->capacity; i++) {
  *    // we know the queue is currently full, so this check is technically
  *    // unnecessary here
@@ -84,8 +84,16 @@ void* circular_queue_push(circular_queue* const queue, void* elem);
  */
 void* circular_queue_get(const circular_queue* const queue, size_t pos);
 
+/** Function to free queue elements. */
+typedef void (*free_elem_fn)(void*);
+
 /** Change the capacity of the queue, reallocating and copying if necessary.
+ *
+ *  @param free_item If the queue size shrinks, removed queue elements are
+ *                   freed using this function.
  *  @return true if queue capacity was successfully updated; false otherwise.
  */
-bool circular_queue_set_capacity(circular_queue* queue, size_t capacity);
+bool circular_queue_set_capacity(circular_queue* queue,
+                                 size_t capacity,
+                                 free_elem_fn free_elem);
 #endif

--- a/src/circular_queue.h
+++ b/src/circular_queue.h
@@ -7,7 +7,8 @@
 #ifndef CIRCULAR_QUEUE_H
 #define CIRCULAR_QUEUE_H
 
-#include <stddef.h>  // size_t
+#include <stdbool.h>  // bool
+#include <stddef.h>   // size_t
 
 typedef struct
 {
@@ -83,5 +84,8 @@ void* circular_queue_push(circular_queue* const queue, void* elem);
  */
 void* circular_queue_get(const circular_queue* const queue, size_t pos);
 
-void circular_queue_set_capacity(circular_queue* queue, size_t capacity);
+/** Change the capacity of the queue, reallocating and copying if necessary.
+ *  @return true if queue capacity was successfully updated; false otherwise.
+ */
+bool circular_queue_set_capacity(circular_queue* queue, size_t capacity);
 #endif

--- a/src/circular_queue.h
+++ b/src/circular_queue.h
@@ -11,30 +11,69 @@
 
 typedef struct
 {
-  void** entries;   /**< The entries must be allocated on the heap. */
+  void** entries;
   size_t count;     /**< The total number of entries ever saved. */
   size_t capacity;  /**< The number of entries allocated for. */
 } circular_queue;
 
 circular_queue* circular_queue_init(size_t capacity);
 
-/** Append an element to the end of the queue.
- *
- *  @note elem must be allocated on the heap. If the queue is full, an existing
- *        entry will be removed and automatically deallocated.
- */
-void circular_queue_push(circular_queue* const queue, void* elem);
-
-/** Get the element at an absolute position in the queue.
+/** Free the queue, the entries must be free'd first.
  *
  *  @code
  *  #include <assert.h>
  *  #include <string.h>
  *
+ *  circular_queue* queue = circular_queue_init(3);
+ *  assert(!circular_queue_push(queue, strdup("elem0")));
+ *  assert(!circular_queue_push(queue, strdup("elem1")));
+ *  for (size_t i = 0; i < queue->capacity; i++) {
+ *    if (queue->entries[i]) {
+ *      free(queue->entries[i]);
+ *    }
+ *  }
+ *  circular_queue_free(queue);
+ *  @endcodek
+ */
+void circular_queue_free(circular_queue* queue);
+
+/** Append an element to the end of the queue, returning the one it replaces.
+ *
+ *  @note If the return value is ignored and it was heap-allocated, memory will
+ *        have been leaked.
+ *  @code
+ *  #include <assert.h>
+ *  #include <string.h>
+ *
  *  circular_queue* queue = circular_queue_init(2);
- *  circular_queue_push(queue, strdup("elem0"));
- *  circular_queue_push(queue, strdup("elem1"));
- *  circular_queue_push(queue, strdup("elem2"));
+ *  assert(!circular_queue_push(queue, strdup("elem0")));
+ *  assert(!circular_queue_push(queue, strdup("elem1")));
+ *
+ *  char* old = circular_queue_push(queue, strdup("elem2")));
+ *  assert(old);
+ *  free(old);
+ *  
+ *  for (size_t i = 0; i < queue->capacity; i++) {
+ *    // we know the queue is currently full, so this check is technically
+ *    // unnecessary here
+ *    if (queue->entries[i]) {
+ *      free(queue->entries[i]);
+ *    }
+ *  }
+ *  circular_queue_free(queue);
+ *  @endcode
+ */
+void* circular_queue_push(circular_queue* const queue, void* elem);
+
+/** Get the element at an absolute position in the queue.
+ *
+ *  @code
+ *  #include <assert.h>
+ *
+ *  circular_queue* queue = circular_queue_init(2);
+ *  circular_queue_push(queue, "elem0");
+ *  circular_queue_push(queue, "elem1");
+ *  circular_queue_push(queue, "elem2");
  *  assert(!circular_queue_get(queue, 0));
  *  assert(circular_queue_get(queue, 1));
  *  assert(circular_queue_get(queue, 2));
@@ -45,7 +84,4 @@ void circular_queue_push(circular_queue* const queue, void* elem);
 void* circular_queue_get(const circular_queue* const queue, size_t pos);
 
 void circular_queue_set_capacity(circular_queue* queue, size_t capacity);
-
-void circular_queue_free(circular_queue* queue);
-
 #endif

--- a/src/circular_queue.h
+++ b/src/circular_queue.h
@@ -1,0 +1,29 @@
+/** Fixed size circular queue with explicit growth/shrink functionality.
+ *
+ * @file
+ *
+ */
+
+#ifndef CIRCULAR_QUEUE_H
+#define CIRCULAR_QUEUE_H
+
+#include <stddef.h>  // size_t
+
+typedef struct {
+  void** entries;
+  size_t capacity;
+} circular_queue;
+
+circular_queue*
+circular_queue_init(size_t capacity);
+
+void
+circular_queue_push(circular_queue* queue, void* elem);
+
+void
+circular_queue_set_capacity(circular_queue* queue, size_t capacity);
+
+void
+circular_queue_free(circular_queue* queue);
+
+#endif

--- a/src/circular_queue.h
+++ b/src/circular_queue.h
@@ -9,21 +9,43 @@
 
 #include <stddef.h>  // size_t
 
-typedef struct {
-  void** entries;
-  size_t capacity;
+typedef struct
+{
+  void** entries;   /**< The entries must be allocated on the heap. */
+  size_t count;     /**< The total number of entries ever saved. */
+  size_t capacity;  /**< The number of entries allocated for. */
 } circular_queue;
 
-circular_queue*
-circular_queue_init(size_t capacity);
+circular_queue* circular_queue_init(size_t capacity);
 
-void
-circular_queue_push(circular_queue* queue, void* elem);
+/** Append an element to the end of the queue.
+ *
+ *  @note elem must be allocated on the heap. If the queue is full, an existing
+ *        entry will be removed and automatically deallocated.
+ */
+void circular_queue_push(circular_queue* const queue, void* elem);
 
-void
-circular_queue_set_capacity(circular_queue* queue, size_t capacity);
+/** Get the element at an absolute position in the queue.
+ *
+ *  @code
+ *  #include <assert.h>
+ *  #include <string.h>
+ *
+ *  circular_queue* queue = circular_queue_init(2);
+ *  circular_queue_push(queue, strdup("elem0"));
+ *  circular_queue_push(queue, strdup("elem1"));
+ *  circular_queue_push(queue, strdup("elem2"));
+ *  assert(!circular_queue_get(queue, 0));
+ *  assert(circular_queue_get(queue, 1));
+ *  assert(circular_queue_get(queue, 2));
+ *  circular_queue_free(queue);
+ *  @endcode
+ *  @return The element if it exists; NULL if not.
+ */
+void* circular_queue_get(const circular_queue* const queue, size_t pos);
 
-void
-circular_queue_free(circular_queue* queue);
+void circular_queue_set_capacity(circular_queue* queue, size_t capacity);
+
+void circular_queue_free(circular_queue* queue);
 
 #endif

--- a/src/history.c
+++ b/src/history.c
@@ -24,6 +24,7 @@ typedef struct _hist_state
 } HISTORY_STATE;
 
 // Function prototypes
+static void history_free_elem(void* elem);
 histdata_t free_hist_entry(HIST_ENTRY*);
 
 // Public global variables
@@ -153,35 +154,17 @@ history_add(const char* string)
 void
 history_stifle(const int max)
 {
-  circular_queue_set_capacity(state.queue, max);
-  // use below as reference for circular_queue_set_capacity
-  // if (max < 0) {
-  // // can't record a negative number of commands
-  // return;
-  // }
+  circular_queue_set_capacity(state.queue, max, history_free_elem);
+}
 
-  // if (state.size == max) {
-  // return;
-  // }
-
-  // if (state.length > max) {
-  // int start = state.count - max + 1;
-  // HIST_ENTRY** list = malloc(sizeof(HIST_ENTRY) * max);
-  // for (int i = 0; i < max; i++) {
-  // HIST_ENTRY* entry = state.entries[(start + i) % state.size];
-  // list[i] = entry;
-  // }
-
-  // free(state.entries);
-  // state.entries = list;
-  // state.length = max;
-  // state.count = max - 1;
-  // } else if (state.length < max) {
-  // state.entries = realloc(state.entries, sizeof(HIST_ENTRY) * max);
-  // }
-
-  // state.size = max;
-  // history_max_entries = state.size;
+static void
+history_free_elem(void* elem)
+{
+  HIST_ENTRY* entry = elem;
+  histdata_t* data = free_hist_entry(entry);
+  if (data) {
+    free(data);
+  }
 }
 
 histdata_t

--- a/src/history.c
+++ b/src/history.c
@@ -29,9 +29,6 @@ static void history_free_entry_and_data(void*);
 static histdata_t history_free_entry(HIST_ENTRY*);
 static int parse_command(const char*, int*);
 
-// Public global variables
-int history_length;
-
 // Private global variables
 HISTORY_STATE state;
 
@@ -39,7 +36,6 @@ void
 history_init()
 {
   state.queue = circular_queue_init(HISTSIZE);
-  history_length = 0;
 }
 
 void
@@ -168,14 +164,18 @@ history_add(const char* string)
   if (removed) {
     history_free_entry_and_data(removed);
   }
-
-  history_length++;
 }
 
 void
 history_stifle(const int max)
 {
   circular_queue_set_capacity(state.queue, max, history_free_entry_and_data);
+}
+
+void
+history_print_all()
+{
+  history_print(state.queue->count);
 }
 
 void

--- a/src/history.c
+++ b/src/history.c
@@ -6,6 +6,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "circular_queue.h"
+
 typedef void* histdata_t;
 
 typedef struct _hist_entry
@@ -18,14 +20,11 @@ typedef struct _hist_entry
 /** A structure used to pass around the current state of the history. */
 typedef struct _hist_state
 {
-  HIST_ENTRY** entries; /**< Pointer to the entries themselves. */
-  int count;            /**< The total number of items ever saved. */
-  int length;           /**< Number of elements within this array. */
-  int size;             /**< Number of slots allocated to this array. */
+  circular_queue* queue;
 } HISTORY_STATE;
 
 // Function prototypes
-histdata_t free_hist_entry(const HIST_ENTRY*);
+histdata_t free_hist_entry(HIST_ENTRY*);
 
 // Public global variables
 int history_length;
@@ -37,28 +36,42 @@ HISTORY_STATE state;
 void
 history_init()
 {
-  state.count = 0;
-  state.length = 0;
-  history_length = state.length;
-  state.size = HISTSIZE;
-  history_max_entries = state.size;
-  state.entries = malloc(sizeof(HIST_ENTRY*) * state.size);
-  for (int i = 0; i < state.size; i++) {
-    state.entries[i] = NULL;
-  }
+  state.queue = circular_queue_init(HISTSIZE);
+  history_length = 0;
+  history_max_entries = HISTSIZE;
 }
 
-int
-history_exp(const char* string, char** output)
+void
+history_free()
 {
-  *output = NULL;
+  for (size_t i = 0; i < state.queue->capacity; i++) {
+    HIST_ENTRY* e = state.queue->entries[i];
+    if (e) {
+      void* data = free_hist_entry(e);
+      if (data) {
+        free(data);
+      }
+    }
+  }
 
-  // Ensure string is nonempty.
+  circular_queue_free(state.queue);
+}
+
+/** Parse history event from history command.
+ *
+ *  @return 1 if valid history command; 0 if not a history command; -1 if an
+ *          error occurred.
+ */
+static int
+parse_command(const char* string, int* output)
+{
+  *output = 0;
+
   if (string[0] == '\0') {
     return 0;
   }
 
-  // Skip blank characters at the start of the string.
+  // Skip blank characters at the start of the string
   int i = 0;
   for (; isspace(string[i]) && string[i] != '\n' && string[i] != '\0'; i++)
     ;
@@ -72,20 +85,45 @@ history_exp(const char* string, char** output)
     return -1;
   }
 
-  // Ensure command is within the bounds of the size of the history.
-  if (command < 0) {
-    if (command <= -state.size) {
-      return -1;
-    }
+  *output = command;
+  return 1;
+}
 
-    command = state.count + command;
-  } else {
-    if (command < (state.count - HISTSIZE) || command > state.count) {
-      return -1;
-    }
+int
+history_exp(const char* string, char** output)
+{
+  *output = NULL;
+
+  int command;
+  const int result = parse_command(string, &command);
+  if (result != 1) {
+    return result;
   }
 
-  if (!(*output = strdup(state.entries[command]->line))) {
+  size_t pos = 0;
+  if (command == 0) {
+    fprintf(stderr, "-bsh: %s: event not found\n", string);
+    return -1;
+  } else if (command < 0) {
+    const size_t pos_command = -command;
+    if (pos_command > state.queue->count) {
+      fprintf(stderr, "-bsh: %s: event not found\n", string);
+      return -1;
+    }
+
+    pos = state.queue->count - pos_command;
+  } else {
+    // !1 is the 0th history entry
+    pos = command - 1;
+  }
+
+  HIST_ENTRY* entry = circular_queue_get(state.queue, pos);
+  if (!entry) {
+    fprintf(stderr, "-bsh: %s: event not found\n", string);
+    return -1;
+  }
+
+  if (!(*output = strdup(entry->line))) {
     return -1;
   }
 
@@ -95,88 +133,87 @@ history_exp(const char* string, char** output)
 void
 history_add(const char* string)
 {
-  char* dup_string = strdup(string);
-
-  HIST_ENTRY* entry = state.entries[state.count % state.size];
-  if (entry) {
-    histdata_t data = free_hist_entry(entry);
-    if (data) free(data);
-  } else {
-    state.length++;
+  if (state.queue->count < state.queue->capacity) {
     history_length++;
   }
 
-  entry = malloc(sizeof(HIST_ENTRY));
-
-  // Calculate timestamp.
-  int prev = (state.count - 1) % state.size;
-  if (prev < 0) prev = state.size - 1;
-  int prev_timestamp = state.entries[prev] ? state.entries[prev]->timestamp : 0;
-
-  entry->line = dup_string;
-  entry->timestamp = prev_timestamp + 1;
+  HIST_ENTRY* entry = malloc(sizeof(HIST_ENTRY));
+  entry->line = strdup(string);
+  entry->timestamp = state.queue->count + 1;
   entry->data = NULL;
-  state.entries[state.count % state.size] = entry;
-
-  state.count++;
+  HIST_ENTRY* removed = circular_queue_push(state.queue, entry);
+  if (removed) {
+    void* data = free_hist_entry(removed);
+    if (data) {
+      free(data);
+    }
+  }
 }
 
 void
 history_stifle(const int max)
 {
-  if (max < 0) {
-    // can't record a negative number of commands
-    return;
-  }
+  circular_queue_set_capacity(state.queue, max);
+  // use below as reference for circular_queue_set_capacity
+  // if (max < 0) {
+  // // can't record a negative number of commands
+  // return;
+  // }
 
-  if (state.size == max) {
-    return;
-  }
+  // if (state.size == max) {
+  // return;
+  // }
 
-  if (state.length > max) {
-    int start = state.count - max + 1;
-    HIST_ENTRY** list = malloc(sizeof(HIST_ENTRY) * max);
-    for (int i = 0; i < max; i++) {
-      HIST_ENTRY* entry = state.entries[(start + i) % state.size];
-      list[i] = entry;
-    }
+  // if (state.length > max) {
+  // int start = state.count - max + 1;
+  // HIST_ENTRY** list = malloc(sizeof(HIST_ENTRY) * max);
+  // for (int i = 0; i < max; i++) {
+  // HIST_ENTRY* entry = state.entries[(start + i) % state.size];
+  // list[i] = entry;
+  // }
 
-    free(state.entries);
-    state.entries = list;
-    state.length = max;
-    state.count = max - 1;
-  } else if (state.length < max) {
-    state.entries = realloc(state.entries, sizeof(HIST_ENTRY) * max);
-  }
+  // free(state.entries);
+  // state.entries = list;
+  // state.length = max;
+  // state.count = max - 1;
+  // } else if (state.length < max) {
+  // state.entries = realloc(state.entries, sizeof(HIST_ENTRY) * max);
+  // }
 
-  state.size = max;
-  history_max_entries = state.size;
+  // state.size = max;
+  // history_max_entries = state.size;
 }
 
 histdata_t
-free_hist_entry(const HIST_ENTRY* histent)
+free_hist_entry(HIST_ENTRY* histent)
 {
-  if (histent->line) free(histent->line);
+  if (histent->line) {
+    free(histent->line);
+  }
+
   histdata_t data = histent->data;
-  free((HIST_ENTRY*)histent);
+  free(histent);
   return data;
 }
 
 void
 history_print(const int num)
 {
-  if (num < state.length) return;
-  int start = state.count % state.size;
-  if (start >= state.length) start = 0;
+  const int start = state.queue->count % state.queue->capacity;
+  for (int i = start; i < num; i++) {
+    HIST_ENTRY* entry = state.queue->entries[i];
+    if (!entry) {
+      return;
+    }
 
-  for (int i = start; (i < state.length) && (i < num); i++) {
-    HIST_ENTRY* entry = state.entries[i];
-    if (!entry) continue;
     printf("\t%d\t%s\n", entry->timestamp, entry->line);
   }
+
   for (int i = 0; (i < start) && (i < num); i++) {
-    HIST_ENTRY* entry = state.entries[i];
-    if (!entry) continue;
+    HIST_ENTRY* entry = state.queue->entries[i];
+    if (!entry) {
+      continue;
+    }
     printf("\t%d\t%s\n", entry->timestamp, entry->line);
   }
 }

--- a/src/history.h
+++ b/src/history.h
@@ -17,9 +17,6 @@
 /** Default maximum number of history entries. */
 #define HISTSIZE 10
 
-/** The number of entries currently stored in the history list. */
-extern int history_length;
-
 /** Initialize alias data structures.
  *
  *  @note Must be called before other history functions can be used.
@@ -47,7 +44,10 @@ void history_add(const char* string);
 /** Stifle the history list, remembering only the last max entries. */
 void history_stifle(int max);
 
-/** Print history list. */
+/** Print all entries in history list. */
+void history_print_all();
+
+/** Print n_last_entries in history list. */
 void history_print(size_t n_last_entries);
 
 /** Print history usage string. */

--- a/src/history.h
+++ b/src/history.h
@@ -30,6 +30,8 @@ extern int history_max_entries;
  */
 void history_init();
 
+void history_free();
+
 /** Expand string, placing the result into output, a pointer to a string.
  *
  *  @note Unlike GNU History, output only needs to be freed if expansion

--- a/src/history.h
+++ b/src/history.h
@@ -12,17 +12,13 @@
 #ifndef HISTORY_H
 #define HISTORY_H
 
+#include <stddef.h>  // size_t
+
 /** Default maximum number of history entries. */
 #define HISTSIZE 10
 
 /** The number of entries currently stored in the history list. */
 extern int history_length;
-
-/** Maximum number of history entries.
- *
- * @see history_stifle
- */
-extern int history_max_entries;
 
 /** Initialize alias data structures.
  *
@@ -52,7 +48,7 @@ void history_add(const char* string);
 void history_stifle(int max);
 
 /** Print history list. */
-void history_print(int num);
+void history_print(size_t n_last_entries);
 
 /** Print history usage string. */
 void history_help();

--- a/src/history.h
+++ b/src/history.h
@@ -32,7 +32,8 @@ void history_init();
 
 /** Expand string, placing the result into output, a pointer to a string.
  *
- *  @note Unlike GNU History, output only needs to be freed if expansion occurrs.
+ *  @note Unlike GNU History, output only needs to be freed if expansion
+ *        occurrs.
  *  @param string The history command.
  *  @param[out] output The command found in history if it exists.
  *  @return

--- a/src/main.c
+++ b/src/main.c
@@ -248,14 +248,14 @@ main(int argc, char** argv)
       continue;
     } else if (his_res == 1) {
       const size_t oldsz = (strlen(cmd_line) + 1) * sizeof(char);
-      const size_t newsz = strlcpy(cmd_line, expansion, oldsz);
+      const size_t newsz = strlcpy(cmd_line, expansion, oldsz) + 1;
       if (newsz > oldsz) {
         if (!(cmd_line = reallocf(cmd_line, newsz))) {
           free(expansion);
           continue;
         }
 
-        size_t check = strlcpy(cmd_line, expansion, newsz);
+        size_t check = strlcpy(cmd_line, expansion, newsz) + 1;
         assert(check == newsz);
       }
 

--- a/src/main.c
+++ b/src/main.c
@@ -224,7 +224,7 @@ main(int argc, char** argv)
     if (!(cmd_line = readline(prompt))) {
       // Quit on EOF terminated empty line.
       printf("\n");
-      exit(EXIT_SUCCESS);
+      break;
     }
 
     // check command line length
@@ -305,4 +305,7 @@ main(int argc, char** argv)
       job_free(j);
     }
   }
+
+  history_free();
+  return EXIT_SUCCESS;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -15,3 +15,15 @@ trim_right(char* s)
   s[i + 1] = '\0';
   return i + 1;
 }
+
+size_t
+min(size_t a, size_t b)
+{
+  return (a <= b) ? a : b;
+}
+
+size_t
+safe_sub(size_t lhs, size_t rhs, size_t default_value)
+{
+  return (lhs > rhs) ? lhs - rhs : default_value;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -12,6 +12,12 @@
 /** Silence unused variable warnings. */
 #define UNUSED(x) (void)(x)
 
+/** Get size of struct member.
+ *
+ *  http://stackoverflow.com/a/3553321/4228400
+ */
+#define MEMBER_SIZE(type, member) (sizeof(((type *)0)->member))
+
 /** Remove trailing whitespace.
  *
  *  @return New length of s.

--- a/src/util.h
+++ b/src/util.h
@@ -16,7 +16,7 @@
  *
  *  http://stackoverflow.com/a/3553321/4228400
  */
-#define MEMBER_SIZE(type, member) (sizeof(((type *)0)->member))
+#define MEMBER_SIZE(type, member) (sizeof(((type*)0)->member))
 
 /** Remove trailing whitespace.
  *

--- a/src/util.h
+++ b/src/util.h
@@ -23,4 +23,7 @@
  *  @return New length of s.
  */
 size_t trim_right(char* s);
+
+size_t min(size_t a, size_t b);
+size_t safe_sub(size_t lhs, size_t rhs, size_t default_value);
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TEST_BSH_SOURCES
 )
 set(TEST_BSH_HEADERS
   test_bsh.h
+  test_utils.h
 )
 add_executable(check_bsh ${TEST_BSH_HEADERS} ${TEST_BSH_SOURCES})
 target_link_libraries(check_bsh bsh ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(Threads)
 
 set(TEST_BSH_SOURCES
   test_bsh_alias.c
+  test_bsh_circular_queue.c
   test_bsh_history.c
   test_bsh_job.c
   test_bsh_main.c

--- a/tests/test_bsh.h
+++ b/tests/test_bsh.h
@@ -6,6 +6,7 @@ void stack_setup();
 void stack_teardown();
 
 Suite* make_alias_suite();
+Suite* make_circular_queue_suite();
 Suite* make_history_suite();
 Suite* make_job_suite();
 Suite* make_stack_suite();

--- a/tests/test_bsh_alias.c
+++ b/tests/test_bsh_alias.c
@@ -16,7 +16,7 @@ alias_teardown()
 
 START_TEST(test_alias_add_expand)
 {
-  char* argv[] = {"alias", "bob=echo"};
+  char* argv[] = { "alias", "bob=echo" };
   ck_assert_int_eq(alias(2, argv), 0);
 
   char* expansion;
@@ -28,13 +28,13 @@ END_TEST
 
 START_TEST(test_alias_print_several)
 {
-  char* argv[] = {"alias", "bob=echo"};
+  char* argv[] = { "alias", "bob=echo" };
   ck_assert_int_eq(alias(2, argv), 0);
 
-  char* argv2[] = {"alias", "harry=echo"};
+  char* argv2[] = { "alias", "harry=echo" };
   ck_assert_int_eq(alias(2, argv2), 0);
 
-  char* argv_print[] = {"alias", "bob", "harry"};
+  char* argv_print[] = { "alias", "bob", "harry" };
   ck_assert_int_eq(alias(3, argv_print), 0);
 }
 END_TEST
@@ -42,40 +42,40 @@ END_TEST
 START_TEST(test_alias_print_some_do_not_exist)
 {
 
-  char* argv[] = {"alias", "bob=echo"};
+  char* argv[] = { "alias", "bob=echo" };
   ck_assert_int_eq(alias(2, argv), 0);
 
-  char* argv_print[] = {"alias", "bob", "harry"};
+  char* argv_print[] = { "alias", "bob", "harry" };
   ck_assert_int_ne(alias(3, argv_print), 0);
 }
 END_TEST
 
 START_TEST(test_alias_print_all)
 {
-  char* argv[] = {"alias", "bob=echo"};
+  char* argv[] = { "alias", "bob=echo" };
   ck_assert_int_eq(alias(2, argv), 0);
 
-  char* argv2[] = {"alias", "harry=echo"};
+  char* argv2[] = { "alias", "harry=echo" };
   ck_assert_int_eq(alias(2, argv2), 0);
 
-  char* argv_print[] = {"alias"};
+  char* argv_print[] = { "alias" };
   ck_assert_int_eq(alias(1, argv_print), 0);
 }
 END_TEST
 
 START_TEST(test_unalias_no_args)
 {
-  char* argv[] = {"unalias"};
+  char* argv[] = { "unalias" };
   ck_assert_int_ne(unalias(1, argv), 0);
 }
 END_TEST
 
 START_TEST(test_unalias_exists)
 {
-  char* argv_alias[] = {"alias", "bob=echo"};
+  char* argv_alias[] = { "alias", "bob=echo" };
   ck_assert_int_eq(alias(2, argv_alias), 0);
 
-  char* argv_unalias[] = {"unalias", "bob"};
+  char* argv_unalias[] = { "unalias", "bob" };
   ck_assert_int_eq(unalias(2, argv_unalias), 0);
 
   char* expansion;
@@ -86,20 +86,20 @@ END_TEST
 
 START_TEST(test_unalias_does_not_exist)
 {
-  char* argv[] = {"unalias", "bob"};
+  char* argv[] = { "unalias", "bob" };
   ck_assert_int_ne(unalias(2, argv), 0);
 }
 END_TEST
 
 START_TEST(test_unalias_remove_all)
 {
-  char* argv_alias[] = {"alias", "bob=echo"};
+  char* argv_alias[] = { "alias", "bob=echo" };
   ck_assert_int_eq(alias(2, argv_alias), 0);
 
-  char* argv_alias2[] = {"alias", "harry=echo"};
+  char* argv_alias2[] = { "alias", "harry=echo" };
   ck_assert_int_eq(alias(2, argv_alias2), 0);
 
-  char* argv[] = {"unalias", "-a"};
+  char* argv[] = { "unalias", "-a" };
   ck_assert_int_eq(unalias(2, argv), 0);
 }
 END_TEST
@@ -109,7 +109,6 @@ START_TEST(test_alias_expand_does_not_exist)
   char* expansion = NULL;
   ck_assert_int_eq(alias_exp("alias", &expansion), 0);
   ck_assert(!expansion);
-
 }
 END_TEST
 

--- a/tests/test_bsh_circular_queue.c
+++ b/tests/test_bsh_circular_queue.c
@@ -137,7 +137,7 @@ START_TEST(test_cq_increase_capacity)
   for (int i = 5; i < 10; i++) {
     char* elem;
     ck_assert_int_ge(asprintf(&elem, "elem%d", i), 0);
-    circular_queue_push(queue1, elem);
+    ck_assert_ptr_null(circular_queue_push(queue1, elem));
   }
 
   for (int i = 0; i < 10; i++) {
@@ -182,6 +182,19 @@ START_TEST(test_cq_increase_capacity)
   }
 
   circular_queue_free_helper(queue2);
+}
+END_TEST
+
+START_TEST(test_cq_increase_capacity_correct_slots)
+{
+  circular_queue* queue = circular_queue_init(1);
+  ck_assert_ptr_not_null(queue);
+  ck_assert_ptr_null(circular_queue_push(queue, "elem0"));
+  ck_assert_ptr_not_null(circular_queue_push(queue, "elem1"));
+  ck_assert(circular_queue_set_capacity(queue, 3, NULL));
+  ck_assert_str_eq(queue->entries[1], "elem1");
+  ck_assert_ptr_null(queue->entries[0]);
+  ck_assert_ptr_null(queue->entries[2]);
 }
 END_TEST
 
@@ -285,6 +298,7 @@ make_circular_queue_suite()
   tcase_add_test(tc, test_cq_push_above_capacity);
   tcase_add_test(tc, test_cq_get);
   tcase_add_test(tc, test_cq_increase_capacity);
+  tcase_add_test(tc, test_cq_increase_capacity_correct_slots);
   tcase_add_test(tc, test_cq_decrease_capacity_rollover);
   tcase_add_test(tc, test_cq_decrease_capacity_no_rollover);
 

--- a/tests/test_bsh_circular_queue.c
+++ b/tests/test_bsh_circular_queue.c
@@ -1,0 +1,57 @@
+#include "../src/circular_queue.h"
+#include "test_bsh.h"
+
+#include <check.h>
+
+START_TEST(test_cq_init_free)
+{
+  circular_queue* queue_normal = circular_queue_init(10);
+  ck_assert(queue_normal);
+  circular_queue_free(queue_normal);
+
+  circular_queue* queue_zero = circular_queue_init(0);
+  ck_assert(queue_zero);
+  circular_queue_free(queue_zero);
+}
+END_TEST
+
+START_TEST(test_cq_push_one)
+{
+  
+}
+END_TEST
+
+START_TEST(test_cq_push_above_capacity)
+{
+  
+}
+END_TEST
+
+START_TEST(test_cq_increase_capacity)
+{
+  
+}
+END_TEST
+
+START_TEST(test_cq_decrease_capacity)
+{
+  
+}
+END_TEST
+
+Suite*
+make_circular_queue_suite()
+{
+  Suite* s = suite_create("Circular Queue");
+  TCase* tc = tcase_create("Core");
+  suite_add_tcase(s, tc);
+  // tcase_add_checked_fixture(tc, history_setup, history_teardown);
+
+  tcase_add_test(tc, test_cq_init_free);
+  tcase_add_test(tc, test_cq_push_one);
+  tcase_add_test(tc, test_cq_push_above_capacity);
+  tcase_add_test(tc, test_cq_increase_capacity);
+  tcase_add_test(tc, test_cq_decrease_capacity);
+
+  return s;
+}

--- a/tests/test_bsh_circular_queue.c
+++ b/tests/test_bsh_circular_queue.c
@@ -78,7 +78,7 @@ START_TEST(test_cq_push_above_capacity)
   circular_queue* norm = circular_queue_init(capacity);
   ck_assert_ptr_not_null(norm);
   for (size_t i = 0; i < elems_to_add; i++) {
-    char* dyn_elem;
+    char* dyn_elem = NULL;
     ck_assert_int_ge(asprintf(&dyn_elem, "e%zu", i), 0);
     char* old = circular_queue_push(norm, dyn_elem);
     if (i > capacity) {
@@ -92,7 +92,7 @@ START_TEST(test_cq_push_above_capacity)
   }
 
   for (size_t i = elems_to_add - capacity; i < elems_to_add; i++) {
-    char* expected;
+    char* expected = NULL;
     ck_assert_int_ge(asprintf(&expected, "e%zu", i), 0);
     char* actual = circular_queue_get(norm, i);
     ck_assert_str_eq(actual, expected);
@@ -118,7 +118,7 @@ START_TEST(test_cq_increase_capacity)
   circular_queue* queue1 = circular_queue_init(5);
   ck_assert_ptr_not_null(queue1);
   for (int i = 0; i < 5; i++) {
-    char* elem;
+    char* elem = NULL;
     ck_assert_int_ge(asprintf(&elem, "elem%d", i), 0);
     ck_assert_ptr_null(circular_queue_push(queue1, elem));
   }
@@ -127,7 +127,7 @@ START_TEST(test_cq_increase_capacity)
 
   // verify set capacity does not affect queue get
   for (int i = 0; i < 5; i++) {
-    char* expected;
+    char* expected = NULL;
     ck_assert_int_ge(asprintf(&expected, "elem%d", i), 0);
     char* actual = circular_queue_get(queue1, i);
     ck_assert_str_eq(actual, expected);
@@ -135,13 +135,13 @@ START_TEST(test_cq_increase_capacity)
   }
 
   for (int i = 5; i < 10; i++) {
-    char* elem;
+    char* elem = NULL;
     ck_assert_int_ge(asprintf(&elem, "elem%d", i), 0);
     ck_assert_ptr_null(circular_queue_push(queue1, elem));
   }
 
   for (int i = 0; i < 10; i++) {
-    char* expected;
+    char* expected = NULL;
     ck_assert_int_ge(asprintf(&expected, "elem%d", i), 0);
     char* actual = circular_queue_get(queue1, i);
     ck_assert_str_eq(actual, expected);
@@ -154,7 +154,7 @@ START_TEST(test_cq_increase_capacity)
   circular_queue* queue2 = circular_queue_init(10);
   ck_assert_ptr_not_null(queue2);
   for (int i = 0; i < 15; i++) {
-    char* elem;
+    char* elem = NULL;
     ck_assert_int_ge(asprintf(&elem, "elem%d", i), 0);
     char* old = circular_queue_push(queue2, elem);
     if (old) {
@@ -164,7 +164,7 @@ START_TEST(test_cq_increase_capacity)
 
   ck_assert(circular_queue_set_capacity(queue2, 15, NULL));
   for (int i = 0; i < 5; i++) {
-    char* elem;
+    char* elem = NULL;
     ck_assert_int_ge(asprintf(&elem, "elem%d", i + 15), 0);
     ck_assert_ptr_null(circular_queue_push(queue2, elem));
   }
@@ -174,7 +174,7 @@ START_TEST(test_cq_increase_capacity)
     if (i < 5) {
       ck_assert_ptr_null(actual);
     } else {
-      char* expected;
+      char* expected = NULL;
       ck_assert_int_ge(asprintf(&expected, "elem%d", i), 0);
       ck_assert_str_eq(actual, expected);
       free(expected);
@@ -237,7 +237,7 @@ START_TEST(test_cq_decrease_capacity_rollover)
   circular_queue* queue_noroll_loss2 = circular_queue_init(5);
   ck_assert_ptr_not_null(queue_noroll_loss2);
   for (int i = 0; i < 5; i++) {
-    char* elem;
+    char* elem = NULL;
     ck_assert_int_ge(asprintf(&elem, "elem%d", i), 0);
     ck_assert_ptr_null(circular_queue_push(queue_noroll_loss2, elem));
   }
@@ -248,7 +248,7 @@ START_TEST(test_cq_decrease_capacity_rollover)
     if (i < 2) {
       ck_assert_ptr_null(actual);
     } else {
-      char* expected;
+      char* expected = NULL;
       ck_assert_int_ge(asprintf(&expected, "elem%d", i), 0);
       ck_assert_str_eq(actual, expected);
       free(expected);
@@ -261,7 +261,7 @@ START_TEST(test_cq_decrease_capacity_rollover)
   circular_queue* queue_roll_loss = circular_queue_init(5);
   ck_assert_ptr_not_null(queue_roll_loss);
   for (int i = 0; i < 7; i++) {
-    char* elem;
+    char* elem = NULL;
     ck_assert_int_ge(asprintf(&elem, "elem%d", i), 0);
     char* old = circular_queue_push(queue_roll_loss, elem);
     if (old) {
@@ -275,7 +275,7 @@ START_TEST(test_cq_decrease_capacity_rollover)
     if (i < 4) {
       ck_assert_ptr_null(actual);
     } else {
-      char* expected;
+      char* expected = NULL;
       ck_assert_int_ge(asprintf(&expected, "elem%zu", i), 0);
       ck_assert_str_eq(actual, expected);
       free(expected);

--- a/tests/test_bsh_circular_queue.c
+++ b/tests/test_bsh_circular_queue.c
@@ -1,5 +1,6 @@
 #include "../src/circular_queue.h"
 #include "test_bsh.h"
+#include "test_utils.h"
 
 #include <check.h>
 #include <stdbool.h>
@@ -171,8 +172,9 @@ START_TEST(test_cq_decrease_capacity_no_rollover)
 {
   // decrease non-rollover queue without loss
   circular_queue* queue_roll_noloss = circular_queue_init(5);
-  circular_queue_push(queue_roll_noloss, "elem0");
-  circular_queue_push(queue_roll_noloss, "elem1");
+  ck_assert_ptr_not_null(queue_roll_noloss);
+  ck_assert_ptr_null(circular_queue_push(queue_roll_noloss, "elem0"));
+  ck_assert_ptr_null(circular_queue_push(queue_roll_noloss, "elem1"));
   ck_assert(circular_queue_set_capacity(queue_roll_noloss, 3, NULL));
   ck_assert_str_eq(circular_queue_get(queue_roll_noloss, 0), "elem0");
   ck_assert_str_eq(circular_queue_get(queue_roll_noloss, 1), "elem1");
@@ -180,10 +182,11 @@ START_TEST(test_cq_decrease_capacity_no_rollover)
 
   // decrease non-rollover with loss
   circular_queue* queue_noroll_loss = circular_queue_init(2);
-  circular_queue_push(queue_noroll_loss, "elem0");
-  circular_queue_push(queue_noroll_loss, "elem1");
+  ck_assert_ptr_not_null(queue_noroll_loss);
+  ck_assert_ptr_null(circular_queue_push(queue_noroll_loss, "elem0"));
+  ck_assert_ptr_null(circular_queue_push(queue_noroll_loss, "elem1"));
   ck_assert(circular_queue_set_capacity(queue_noroll_loss, 1, NULL));
-  ck_assert(!circular_queue_get(queue_noroll_loss, 0));
+  ck_assert_ptr_null(circular_queue_get(queue_noroll_loss, 0));
   ck_assert_str_eq(circular_queue_get(queue_noroll_loss, 1), "elem1");
   circular_queue_free(queue_noroll_loss);
 }
@@ -192,20 +195,21 @@ END_TEST
 START_TEST(test_cq_decrease_capacity_rollover)
 {
   circular_queue* queue_noroll_loss2 = circular_queue_init(5);
+  ck_assert_ptr_not_null(queue_noroll_loss2);
   for (int i = 0; i < 5; i++) {
     char* elem;
-    asprintf(&elem, "elem%d", i);
-    circular_queue_push(queue_noroll_loss2, elem);
+    ck_assert_int_ge(asprintf(&elem, "elem%d", i), 0);
+    ck_assert_ptr_null(circular_queue_push(queue_noroll_loss2, elem));
   }
 
   ck_assert(circular_queue_set_capacity(queue_noroll_loss2, 3, free));
   for (int i = 0; i < 5; i++) {
     char* actual = circular_queue_get(queue_noroll_loss2, i);
     if (i < 2) {
-      ck_assert(!actual);
+      ck_assert_ptr_null(actual);
     } else {
       char* expected;
-      asprintf(&expected, "elem%d", i);
+      ck_assert_int_ge(asprintf(&expected, "elem%d", i), 0);
       ck_assert_str_eq(actual, expected);
       free(expected);
     }
@@ -215,11 +219,12 @@ START_TEST(test_cq_decrease_capacity_rollover)
 
   // decrease rollover with loss
   circular_queue* queue_roll_loss = circular_queue_init(5);
+  ck_assert_ptr_not_null(queue_roll_loss);
   for (int i = 0; i < 7; i++) {
     char* elem;
-    asprintf(&elem, "elem%d", i);
-    char* old;
-    if ((old = circular_queue_push(queue_roll_loss, elem))) {
+    ck_assert_int_ge(asprintf(&elem, "elem%d", i), 0);
+    char* old = circular_queue_push(queue_roll_loss, elem);
+    if (old) {
       free(old);
     }
   }
@@ -228,12 +233,12 @@ START_TEST(test_cq_decrease_capacity_rollover)
   for (size_t i = 0; i < queue_roll_loss->count; i++) {
     char* actual = circular_queue_get(queue_roll_loss, i);
     if (i < 4) {
-      ck_assert(!actual);
+      ck_assert_ptr_null(actual);
     } else {
-      char* check;
-      asprintf(&check, "elem%zu", i);
-      ck_assert_str_eq(actual, check);
-      free(check);
+      char* expected;
+      ck_assert_int_ge(asprintf(&expected, "elem%zu", i), 0);
+      ck_assert_str_eq(actual, expected);
+      free(expected);
     }
   }
 

--- a/tests/test_bsh_circular_queue.c
+++ b/tests/test_bsh_circular_queue.c
@@ -206,6 +206,16 @@ START_TEST(test_cq_decrease_capacity_no_rollover)
   ck_assert_ptr_null(circular_queue_get(queue_noroll_loss, 0));
   ck_assert_str_eq(circular_queue_get(queue_noroll_loss, 1), "elem1");
   circular_queue_free(queue_noroll_loss);
+
+  // decrease non-rollover with larger loss
+  circular_queue* queue_noroll_loss2 = circular_queue_init(5);
+  ck_assert_ptr_not_null(queue_noroll_loss2);
+  ck_assert_ptr_null(circular_queue_push(queue_noroll_loss2, "elem0"));
+  ck_assert_ptr_null(circular_queue_push(queue_noroll_loss2, "elem1"));
+  ck_assert(circular_queue_set_capacity(queue_noroll_loss2, 1, NULL));
+  ck_assert_ptr_null(circular_queue_get(queue_noroll_loss2, 0));
+  ck_assert_str_eq(circular_queue_get(queue_noroll_loss2, 1), "elem1");
+  circular_queue_free(queue_noroll_loss2);
 }
 END_TEST
 

--- a/tests/test_bsh_circular_queue.c
+++ b/tests/test_bsh_circular_queue.c
@@ -2,6 +2,9 @@
 #include "test_bsh.h"
 
 #include <check.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 START_TEST(test_cq_init_free)
 {
@@ -9,33 +12,85 @@ START_TEST(test_cq_init_free)
   ck_assert(queue_normal);
   circular_queue_free(queue_normal);
 
-  circular_queue* queue_zero = circular_queue_init(0);
-  ck_assert(queue_zero);
-  circular_queue_free(queue_zero);
+  circular_queue* queue_one = circular_queue_init(1);
+  ck_assert(queue_one);
+  circular_queue_free(queue_one);
 }
 END_TEST
 
 START_TEST(test_cq_push_one)
 {
-  
+  circular_queue* queue = circular_queue_init(10);
+  void* elem = strdup("0th element");
+  circular_queue_push(queue, elem);
+  void* ret = circular_queue_get(queue, 0);
+  ck_assert_ptr_eq(ret, elem);
+  circular_queue_free(queue);
 }
 END_TEST
 
 START_TEST(test_cq_push_above_capacity)
 {
-  
+  // 1 capacity: push is in-place swap
+  circular_queue* queue1 = circular_queue_init(1);
+  void* elem = strdup("count0");
+  circular_queue_push(queue1, elem);
+  void* ret = circular_queue_get(queue1, 0);
+  ck_assert_ptr_eq(ret, elem);
+
+  void* another_elem = strdup("count1");
+  circular_queue_push(queue1, another_elem);
+  ret = circular_queue_get(queue1, 1);
+  ck_assert_ptr_eq(ret, another_elem);
+  circular_queue_free(queue1);
+
+  // 2 capacity: simple to reason about
+  circular_queue* queue2 = circular_queue_init(2);
+  circular_queue_push(queue2, strdup("count0"));
+  circular_queue_push(queue2, strdup("count1"));
+  ck_assert(circular_queue_get(queue2, 0));
+  ck_assert(circular_queue_get(queue2, 1));
+  circular_queue_push(queue2, strdup("count2"));
+  ck_assert(!circular_queue_get(queue2, 0));
+  ck_assert(circular_queue_get(queue2, 1));
+  ck_assert(circular_queue_get(queue2, 2));
+  circular_queue_free(queue2);
+
+  // N capacity: normal case
+  size_t capacity = 10;
+  size_t elems_to_add = 100;
+  circular_queue* norm = circular_queue_init(capacity);
+  for (size_t i = 0; i < elems_to_add; i++) {
+    char* dyn_elem;
+    asprintf(&dyn_elem, "e%zu", i);
+    circular_queue_push(norm, dyn_elem);
+  }
+
+  for (size_t i = 0; i < elems_to_add - capacity; i++) {
+    ck_assert(!(circular_queue_get(norm, i)));
+  }
+
+  for (size_t i = elems_to_add - capacity; i < elems_to_add; i++) {
+    char* computed;
+    asprintf(&computed, "e%zu", i);
+    char* actual = circular_queue_get(norm, i);
+    ck_assert_str_eq(actual, computed);
+    free(computed);
+  }
+
+  circular_queue_free(norm);
 }
 END_TEST
 
 START_TEST(test_cq_increase_capacity)
 {
-  
+  ck_assert(false);
 }
 END_TEST
 
 START_TEST(test_cq_decrease_capacity)
 {
-  
+  ck_assert(false);
 }
 END_TEST
 
@@ -45,7 +100,6 @@ make_circular_queue_suite()
   Suite* s = suite_create("Circular Queue");
   TCase* tc = tcase_create("Core");
   suite_add_tcase(s, tc);
-  // tcase_add_checked_fixture(tc, history_setup, history_teardown);
 
   tcase_add_test(tc, test_cq_init_free);
   tcase_add_test(tc, test_cq_push_one);

--- a/tests/test_bsh_circular_queue.c
+++ b/tests/test_bsh_circular_queue.c
@@ -21,7 +21,7 @@ END_TEST
 START_TEST(test_cq_push_one)
 {
   circular_queue* queue = circular_queue_init(10);
-  void* elem = strdup("0th element");
+  void* elem = "0th element";
   circular_queue_push(queue, elem);
   void* ret = circular_queue_get(queue, 0);
   ck_assert_ptr_eq(ret, elem);
@@ -33,12 +33,12 @@ START_TEST(test_cq_push_above_capacity)
 {
   // 1 capacity: push is in-place swap
   circular_queue* queue1 = circular_queue_init(1);
-  void* elem = strdup("count0");
+  void* elem = "count0";
   circular_queue_push(queue1, elem);
   void* ret = circular_queue_get(queue1, 0);
   ck_assert_ptr_eq(ret, elem);
 
-  void* another_elem = strdup("count1");
+  void* another_elem = "count1";
   circular_queue_push(queue1, another_elem);
   ret = circular_queue_get(queue1, 1);
   ck_assert_ptr_eq(ret, another_elem);
@@ -46,11 +46,11 @@ START_TEST(test_cq_push_above_capacity)
 
   // 2 capacity: simple to reason about
   circular_queue* queue2 = circular_queue_init(2);
-  circular_queue_push(queue2, strdup("count0"));
-  circular_queue_push(queue2, strdup("count1"));
+  circular_queue_push(queue2, "count0");
+  circular_queue_push(queue2, "count1");
   ck_assert(circular_queue_get(queue2, 0));
   ck_assert(circular_queue_get(queue2, 1));
-  circular_queue_push(queue2, strdup("count2"));
+  circular_queue_push(queue2, "count2");
   ck_assert(!circular_queue_get(queue2, 0));
   ck_assert(circular_queue_get(queue2, 1));
   ck_assert(circular_queue_get(queue2, 2));
@@ -63,7 +63,10 @@ START_TEST(test_cq_push_above_capacity)
   for (size_t i = 0; i < elems_to_add; i++) {
     char* dyn_elem;
     asprintf(&dyn_elem, "e%zu", i);
-    circular_queue_push(norm, dyn_elem);
+    char* old = circular_queue_push(norm, dyn_elem);
+    if (old) {
+      free(old);
+    }
   }
 
   for (size_t i = 0; i < elems_to_add - capacity; i++) {
@@ -75,6 +78,7 @@ START_TEST(test_cq_push_above_capacity)
     asprintf(&computed, "e%zu", i);
     char* actual = circular_queue_get(norm, i);
     ck_assert_str_eq(actual, computed);
+    free(actual);
     free(computed);
   }
 

--- a/tests/test_bsh_history.c
+++ b/tests/test_bsh_history.c
@@ -31,16 +31,13 @@ START_TEST(test_history_add_rollover)
 {
   ck_assert_int_eq(history_length, 0);
   for (int i = 0; i < HISTSIZE; i++) {
-    ck_assert(history_length < history_max_entries);
     char* s = NULL;
     ck_assert_int_ge(asprintf(&s, "command%d", i + 1), 0);
     history_add(s);
     free(s);
   }
 
-  ck_assert_int_eq(history_length, history_max_entries);
   history_add("overflow");
-  ck_assert_int_eq(history_length, history_max_entries);
 
   char* expansion = NULL;
   const int his_res = history_exp("!1", &expansion);
@@ -108,18 +105,6 @@ START_TEST(test_history_exp_correct)
 }
 END_TEST
 
-START_TEST(test_history_stifle_increase)
-{
-  ck_assert(false);
-}
-END_TEST
-
-START_TEST(test_history_stifle_decrease)
-{
-  ck_assert(false);
-}
-END_TEST
-
 Suite*
 make_history_suite()
 {
@@ -135,8 +120,6 @@ make_history_suite()
   tcase_add_test(tc, test_history_exp_found_pos);
   tcase_add_test(tc, test_history_exp_invalid_event);
   tcase_add_test(tc, test_history_exp_correct);
-  tcase_add_test(tc, test_history_stifle_increase);
-  tcase_add_test(tc, test_history_stifle_decrease);
 
   return s;
 }

--- a/tests/test_bsh_history.c
+++ b/tests/test_bsh_history.c
@@ -14,27 +14,83 @@ history_setup(void)
 void
 history_teardown(void)
 {
+  history_free();
 }
 
-START_TEST(test_history_add_increments_length)
+START_TEST(test_history_add)
 {
   ck_assert_int_eq(history_length, 0);
-  char* s = strdup("new_command");
-  history_add(s);
+  history_add("command");
   ck_assert_int_eq(history_length, 1);
-  free(s);
 }
 END_TEST
 
-START_TEST(test_history_exp_new_command)
+START_TEST(test_history_add_rollover)
+{
+  ck_assert_int_eq(history_length, 0);
+  for (int i = 0; i < HISTSIZE; i++) {
+    ck_assert(history_length < history_max_entries);
+    char* s;
+    asprintf(&s, "command%d", i + 1);
+    history_add(s);
+    free(s);
+  }
+
+  ck_assert(history_length == history_max_entries);
+
+  history_add("overflow");
+  ck_assert(history_length == history_max_entries);
+
+  char* expansion;
+  const int his_res = history_exp("!1", &expansion);
+  ck_assert_int_eq(his_res, -1);
+}
+END_TEST
+
+START_TEST(test_history_exp_not_found)
 {
   char* expansion;
-  const int his_res = history_exp("new_command", &expansion);
-  ck_assert_int_eq(his_res, 0);
+  const int his_res = history_exp("!1", &expansion);
+  ck_assert_int_eq(his_res, -1);
 }
 END_TEST
 
-START_TEST(test_history_exp_error)
+START_TEST(test_history_exp_found_pos)
+{
+  history_add("command1");
+  char* expansion;
+  const int his_res = history_exp("!1", &expansion);
+  ck_assert_int_eq(his_res, 1);
+  ck_assert_str_eq(expansion, "command1");
+  free(expansion);
+}
+END_TEST
+
+START_TEST(test_history_exp_found_neg)
+{
+  history_add("command1");
+  char* expansion;
+  const int his_res = history_exp("!-1", &expansion);
+  ck_assert_int_eq(his_res, 1);
+  ck_assert_str_eq(expansion, "command1");
+  free(expansion);
+
+  history_add("command2");
+  char* expansion2;
+  const int his_res2 = history_exp("!-1", &expansion2);
+  ck_assert_int_eq(his_res2, 1);
+  ck_assert_str_eq(expansion2, "command2");
+  free(expansion2);
+
+  char* expansion3;
+  const int his_res3 = history_exp("!-2", &expansion3);
+  ck_assert_int_eq(his_res3, 1);
+  ck_assert_str_eq(expansion2, "command1");
+  free(expansion3);
+}
+END_TEST
+
+START_TEST(test_history_exp_invalid_event)
 {
   char* expansion;
   const int his_res = history_exp("!invalid", &expansion);
@@ -42,32 +98,41 @@ START_TEST(test_history_exp_error)
 }
 END_TEST
 
-START_TEST(test_history_exp_occurred)
+START_TEST(test_history_exp_correct)
 {
-  char* s = strdup("new_command");
-  history_add(s);
-  char* expansion;
-  const int his_res = history_exp("!-1\n", &expansion);
-  ck_assert_int_eq(his_res, 1);
-  ck_assert_str_eq(expansion, "new_command");
-  free(s);
+  ck_assert(false);
+}
+END_TEST
+
+START_TEST(test_history_stifle_increase)
+{
+  ck_assert(false);
+}
+END_TEST
+
+START_TEST(test_history_stifle_decrease)
+{
+  ck_assert(false);
 }
 END_TEST
 
 Suite*
-make_history_suite(void)
+make_history_suite()
 {
   Suite* s = suite_create("History");
-
-  /* Core test case. */
   TCase* tc = tcase_create("Core");
-
   suite_add_tcase(s, tc);
   tcase_add_checked_fixture(tc, history_setup, history_teardown);
-  tcase_add_test(tc, test_history_add_increments_length);
-  tcase_add_test(tc, test_history_exp_new_command);
-  tcase_add_test(tc, test_history_exp_error);
-  tcase_add_test(tc, test_history_exp_occurred);
+
+  tcase_add_test(tc, test_history_add);
+  tcase_add_test(tc, test_history_add_rollover);
+  tcase_add_test(tc, test_history_exp_not_found);
+  tcase_add_test(tc, test_history_exp_found_neg);
+  tcase_add_test(tc, test_history_exp_found_pos);
+  tcase_add_test(tc, test_history_exp_invalid_event);
+  tcase_add_test(tc, test_history_exp_correct);
+  tcase_add_test(tc, test_history_stifle_increase);
+  tcase_add_test(tc, test_history_stifle_decrease);
 
   return s;
 }

--- a/tests/test_bsh_history.c
+++ b/tests/test_bsh_history.c
@@ -99,12 +99,6 @@ START_TEST(test_history_exp_invalid_event)
 }
 END_TEST
 
-START_TEST(test_history_exp_correct)
-{
-  ck_assert(false);
-}
-END_TEST
-
 Suite*
 make_history_suite()
 {
@@ -119,7 +113,6 @@ make_history_suite()
   tcase_add_test(tc, test_history_exp_found_neg);
   tcase_add_test(tc, test_history_exp_found_pos);
   tcase_add_test(tc, test_history_exp_invalid_event);
-  tcase_add_test(tc, test_history_exp_correct);
 
   return s;
 }

--- a/tests/test_bsh_history.c
+++ b/tests/test_bsh_history.c
@@ -1,5 +1,7 @@
 #include "../src/history.h"
 #include "test_bsh.h"
+#include "test_utils.h"
+
 #include <check.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -30,35 +32,36 @@ START_TEST(test_history_add_rollover)
   ck_assert_int_eq(history_length, 0);
   for (int i = 0; i < HISTSIZE; i++) {
     ck_assert(history_length < history_max_entries);
-    char* s;
-    asprintf(&s, "command%d", i + 1);
+    char* s = NULL;
+    ck_assert_int_ge(asprintf(&s, "command%d", i + 1), 0);
     history_add(s);
     free(s);
   }
 
-  ck_assert(history_length == history_max_entries);
-
+  ck_assert_int_eq(history_length, history_max_entries);
   history_add("overflow");
-  ck_assert(history_length == history_max_entries);
+  ck_assert_int_eq(history_length, history_max_entries);
 
-  char* expansion;
+  char* expansion = NULL;
   const int his_res = history_exp("!1", &expansion);
   ck_assert_int_eq(his_res, -1);
+  ck_assert_ptr_null(expansion);
 }
 END_TEST
 
 START_TEST(test_history_exp_not_found)
 {
-  char* expansion;
+  char* expansion = NULL;
   const int his_res = history_exp("!1", &expansion);
   ck_assert_int_eq(his_res, -1);
+  ck_assert_ptr_null(expansion);
 }
 END_TEST
 
 START_TEST(test_history_exp_found_pos)
 {
   history_add("command1");
-  char* expansion;
+  char* expansion = NULL;
   const int his_res = history_exp("!1", &expansion);
   ck_assert_int_eq(his_res, 1);
   ck_assert_str_eq(expansion, "command1");
@@ -69,20 +72,20 @@ END_TEST
 START_TEST(test_history_exp_found_neg)
 {
   history_add("command1");
-  char* expansion;
+  char* expansion = NULL;
   const int his_res = history_exp("!-1", &expansion);
   ck_assert_int_eq(his_res, 1);
   ck_assert_str_eq(expansion, "command1");
   free(expansion);
 
   history_add("command2");
-  char* expansion2;
+  char* expansion2 = NULL;
   const int his_res2 = history_exp("!-1", &expansion2);
   ck_assert_int_eq(his_res2, 1);
   ck_assert_str_eq(expansion2, "command2");
   free(expansion2);
 
-  char* expansion3;
+  char* expansion3 = NULL;
   const int his_res3 = history_exp("!-2", &expansion3);
   ck_assert_int_eq(his_res3, 1);
   ck_assert_str_eq(expansion2, "command1");
@@ -92,9 +95,10 @@ END_TEST
 
 START_TEST(test_history_exp_invalid_event)
 {
-  char* expansion;
+  char* expansion = NULL;
   const int his_res = history_exp("!invalid", &expansion);
   ck_assert_int_eq(his_res, -1);
+  ck_assert_ptr_null(expansion);
 }
 END_TEST
 

--- a/tests/test_bsh_history.c
+++ b/tests/test_bsh_history.c
@@ -21,15 +21,15 @@ history_teardown(void)
 
 START_TEST(test_history_add)
 {
-  ck_assert_int_eq(history_length, 0);
   history_add("command");
-  ck_assert_int_eq(history_length, 1);
+  char* actual = NULL;
+  ck_assert_int_eq(history_exp("!1", &actual), 1);
+  ck_assert_str_eq(actual, "command");
 }
 END_TEST
 
 START_TEST(test_history_add_rollover)
 {
-  ck_assert_int_eq(history_length, 0);
   for (int i = 0; i < HISTSIZE; i++) {
     char* s = NULL;
     ck_assert_int_ge(asprintf(&s, "command%d", i + 1), 0);

--- a/tests/test_bsh_main.c
+++ b/tests/test_bsh_main.c
@@ -1,15 +1,18 @@
 #include "test_bsh.h"
+
 #include <check.h>
 #include <stdlib.h>
 
 int
-main(void)
+main()
 {
   SRunner* sr = srunner_create(make_alias_suite());
+  srunner_add_suite(sr, make_circular_queue_suite());
   srunner_add_suite(sr, make_history_suite());
   srunner_add_suite(sr, make_job_suite());
   srunner_add_suite(sr, make_stack_suite());
   srunner_add_suite(sr, make_parse_suite());
+
   srunner_run_all(sr, CK_VERBOSE);
   int num_failed = srunner_ntests_failed(sr);
   srunner_free(sr);

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -1,0 +1,8 @@
+#ifndef TEST_UTILS_H
+#define TEST_UTILS_H
+#include <check.h>
+
+#define ck_assert_ptr_null(expr) ck_assert_ptr_eq(expr, NULL)
+#define ck_assert_ptr_not_null(expr) ck_assert_ptr_ne(expr, NULL)
+
+#endif


### PR DESCRIPTION
TODO

- [x] implement circular_queue_set_capacity
- [x] implement history_stifle
- [x] rename `HIST_STATE` and `HIST_ENTRY` to hist_state and hist_entry
- [x] remove `history_length` or `history_max_entries` or at least make them into thin wrappers around `circular_queue`
- [x] investigate history failure (stifle 2, stifle 10, print)
- ~~change `HIST_STATE` to a parameter not a global~~