### PR TITLE
Fix failing tests on Linux

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+!README.md
+*.md
+.DS_Store
+.clang-format
+.git
+.github
+.gitignore
+.vscode
+azure-pipelines.yml
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(bsh VERSION 0.1.0 DESCRIPTION "Bash-like shell" LANGUAGES C)
 # =============================
 # Project-wide setup
 # =============================
+option(BSH_USE_VALGRIND "Run tests with Valgrind" OFF)
 option(BSH_ENABLE_WERROR "Enable all warnings as errors" ON)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
@@ -76,5 +77,13 @@ endif()
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR AND BUILD_TESTING)
   add_subdirectory(tests)
 
-  add_custom_target(runTests COMMAND bshUnitTests DEPENDS bshUnitTests)
+  if(BSH_USE_VALGRIND)
+    add_custom_target(runTests
+                      COMMAND CK_FORK=no valgrind
+                              --error-exitcode=1
+                              --leak-check=full $<TARGET_FILE:bshUnitTests>
+                      DEPENDS bshUnitTests)
+  else()
+    add_custom_target(runTests COMMAND bshUnitTests DEPENDS bshUnitTests)
+  endif()
 endif()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,22 @@
 This document serves as a style-guide and reference to help ensure consistency
 in the project.
 
+## Building
+
+### Linux in Docker
+
+Use the provided `docker/linux/Dockerfile` to create a Linux container capable
+of building `bsh`. Inside that container, you can use cmake, etc.
+
+```sh
+make build-docker-linux
+make run-docker-linux
+# You are now inside the container
+mkdir -p build/linux/Debug && cd build/linux/Debug
+cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Debug ../../..
+cmake --build . --target runTests
+```
+
 ## Testing
 
 Bsh uses the [Check](http://check.sourceforge.net/) unit testing framework.
@@ -26,6 +42,8 @@ cmake --build . --target runTests # build and run
 - initialize pointers to NULL
 - check for null pointer with `if (ptr)` instead of `if (ptr == NULL)`
 - global variables should be prefixed with `g_`
+- constants in global scope should be prefixed with `c_`
+- struct variables should not use a prefix
 
 ## Documentation
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+makefile_dir = $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
+docker_linux_tag = rgardner/bsh-linux:latest
+
+build-docker-linux:
+	docker build docker/linux --tag $(docker_linux_tag)
+
+run-docker-linux:
+	docker run --interactive --tty --volume $(makefile_dir):/usr/src/bsh --rm \
+		--workdir /usr/src/bsh $(docker_linux_tag) /bin/bash

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,8 +12,11 @@ trigger:
       - "*"
     exclude:
       - .clang-format
+      - .dockerignore
       - CONTRIBUTING.md
+      - Makefile
       - README.md
+      - docker
 
 pr:
   branches:
@@ -24,17 +27,22 @@ pr:
       - "*"
     exclude:
       - .clang-format
+      - .dockerignore
       - CONTRIBUTING.md
+      - Makefile
       - README.md
+      - docker
 
 strategy:
   matrix:
     linux:
       imageName: "ubuntu-latest"
       cmakeGenerator: "Ninja"
+      useValgrind: true
     mac:
       imageName: "macos-latest"
       cmakeGenerator: "Xcode"
+      useValgrind: false
 
 pool:
   vmImage: $(imageName)
@@ -42,7 +50,12 @@ pool:
 steps:
   - bash: |
       set -euo pipefail
-      sudo apt install libbsd-dev libreadline-dev ninja-build pkg-config
+      sudo apt-get install --yes --no-install-recommends \
+        libbsd-dev \
+        libreadline-dev \
+        ninja-build \
+        pkg-config \
+        valgrind
     condition: eq(variables['Agent.OS'], 'Linux')
     displayName: "Install Linux-specific build dependencies"
 
@@ -50,16 +63,17 @@ steps:
       set -euo pipefail
       mkdir -p build/debug
       pushd build/debug
-      cmake -G "${GENERATOR}" -DCMAKE_BUILD_TYPE=Debug ../..
+      cmake -G "${GENERATOR}" -DCMAKE_BUILD_TYPE:STRING=Debug -DBSH_USE_VALGRIND:BOOL="${USE_VALGRIND}" ../..
       cmake --build . --config Debug
       popd
 
       mkdir -p build/release
       pushd build/release
-      cmake -G "${GENERATOR}" -DCMAKE_BUILD_TYPE=Release ../..
+      cmake -G "${GENERATOR}" -DCMAKE_BUILD_TYPE:STRING=Release -DBSH_USE_VALGRIND:BOOL="${USE_VALGRIND}" ../..
       cmake --build . --config Release
     env:
       GENERATOR: $(cmakeGenerator)
+      USE_VALGRIND: $(useValgrind)
     displayName: "Build project"
 
   - script: |

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -1,0 +1,11 @@
+FROM gcc:9.2
+
+# Update and install dependencies, and remove the package manager cache. Do
+# this in a single step for better caching.
+RUN apt-get --yes update && apt-get install --yes --no-install-recommends \
+        cmake \
+        libbsd-dev \
+        libreadline-dev \
+        ninja-build \
+        pkg-config \
+        && rm -rf /var/lib/apt/lists/*

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -8,4 +8,5 @@ RUN apt-get --yes update && apt-get install --yes --no-install-recommends \
         libreadline-dev \
         ninja-build \
         pkg-config \
+        valgrind \
         && rm -rf /var/lib/apt/lists/*

--- a/src/alias.c
+++ b/src/alias.c
@@ -45,6 +45,12 @@ aliases_init()
   aliases = ll_init();
 }
 
+void
+aliases_deinit()
+{
+  ll_free(aliases);
+}
+
 /**
  * Initializes a new alias.
  *
@@ -130,12 +136,7 @@ unalias(const int argc, char** argv)
 
   // remove all aliases
   if (strcmp(argv[1], "-a") == 0) {
-    while (aliases->head) {
-      Alias* alias = ll_remove(aliases);
-      assert(alias);
-      alias_free(alias);
-    }
-
+    unalias_all();
     return c_bsh_alias_error_success;
   }
 
@@ -148,6 +149,14 @@ unalias(const int argc, char** argv)
   }
 
   return all_found ? 0 : 1;
+}
+
+void unalias_all() {
+  while (aliases->head) {
+    Alias* alias = ll_remove(aliases);
+    assert(alias);
+    alias_free(alias);
+  }
 }
 
 void

--- a/src/alias.h
+++ b/src/alias.h
@@ -9,11 +9,19 @@
 #ifndef ALIAS_H
 #define ALIAS_H
 
+enum bsh_alias_error
+{
+  c_bsh_alias_error_success = 0,
+  c_bsh_alias_error_general = 1,
+  c_bsh_alias_error_usage = 2,
+};
+
 /** Initialize alias data structures.
  *
  *  @note Must be called before other alias functions can be used.
  */
-void aliases_init();
+void
+aliases_init();
 
 /** The alias builtin command that prints existing aliases and creates new ones.
  *
@@ -24,20 +32,24 @@ void aliases_init();
  *  @endcode
  *  @return 0 on success; any positive value on failure.
  */
-int alias(int argc, char** argv);
+int
+alias(int argc, char** argv);
 
 /** Print alias usage and exit. */
-void alias_help();
+void
+alias_help();
 
 /** Remove alias entry.
  *
  *  @return 0 if the alias was successfully removed; 1 if the alias does not
             exist.
  */
-int unalias(int argc, char** argv);
+int
+unalias(int argc, char** argv);
 
 /** Print unalias usage and exit. */
-void unalias_help();
+void
+unalias_help();
 
 /** Expand alias value for string.
  *
@@ -49,5 +61,7 @@ void unalias_help();
  *  1 if an expansion occurred;
  *  -1 if there was an error in the expansion.
  */
-int alias_exp(const char* name, char** output);
+int
+alias_exp(const char* name, char** output);
+
 #endif

--- a/src/alias.h
+++ b/src/alias.h
@@ -23,6 +23,9 @@ enum bsh_alias_error
 void
 aliases_init();
 
+void
+aliases_deinit();
+
 /** The alias builtin command that prints existing aliases and creates new ones.
  *
  *  @code{.sh}
@@ -46,6 +49,8 @@ alias_help();
  */
 int
 unalias(int argc, char** argv);
+
+void unalias_all();
 
 /** Print unalias usage and exit. */
 void

--- a/src/circular_queue.h
+++ b/src/circular_queue.h
@@ -44,7 +44,7 @@ circular_queue* circular_queue_init(size_t capacity);
  *    }
  *  }
  *  circular_queue_free(queue, NULL);
- *  @endcodek
+ *  @endcode
  */
 void circular_queue_free(circular_queue* queue, free_elem_fn free_elem);
 

--- a/src/job.c
+++ b/src/job.c
@@ -101,6 +101,7 @@ init_job(job* j,
   j->next = NULL;
   /* TODO: use original command entered here, not stored in info. */
   j->command = NULL;
+  j->first_process = NULL;
 
   process* prev = NULL;
   for (int i = 0; i <= info->pipeNum; i++) {
@@ -145,28 +146,33 @@ error:
 void
 process_free(process* p)
 {
+  if (!p) return;
+
   for (int i = 0; i < p->argc; i++) {
     free(p->argv[i]);
+    p->argv[i] = NULL;
   }
 
-  for (process* next = p->next; next; next = next->next) {
-    process_free(next);
-  }
+  free(p->argv);
+  p->argv = NULL;
+
+  process_free(p->next);
+  free(p->next);
+  p->next = NULL;
 }
 
 void
 job_free(job* j)
 {
-  job* curr = j;
-  while (curr) {
-    free(curr->command);
-    for (process* p = curr->first_process; p; p = p->next) {
-      process_free(p);
-    }
-    job* next = curr->next;
-    free(curr);
-    curr = next;
-  }
+  if (!j) return;
+
+  free(j->command);
+  process_free(j->first_process);
+  free(j->first_process);
+  j->first_process = NULL;
+
+  job_free(j->next);
+  j->next = NULL;
 }
 
 void

--- a/src/job.h
+++ b/src/job.h
@@ -6,6 +6,12 @@
 #include <termios.h>
 #include <unistd.h>
 
+enum bsh_job_error
+{
+  c_bsh_job_error_success = 0,
+  c_bsh_job_error_general = 1,
+};
+
 /* A process is a single process.  */
 typedef struct process
 {
@@ -30,11 +36,15 @@ typedef struct job
   int infile, outfile, errfile; /* standard i/o channels */
 } job;
 
-void process_free(process*);
+void
+process_free(process*);
 
-void init_job(job*, const struct ParseInfo*, pid_t, struct termios);
+enum bsh_job_error
+init_job(job*, const struct ParseInfo*, pid_t, struct termios);
 
-void job_free(job*);
+void
+job_free(job*);
 
-void job_print(job*);
+void
+job_print(job*);
 #endif

--- a/src/linked_list.c
+++ b/src/linked_list.c
@@ -40,6 +40,7 @@ ll_add(struct LinkedList* list, const int index, const void* element)
   int i;
   for (i = 0; (i < index) && (current->next); i++)
     current = current->next;
+
   if (current->next) new->next = current->next->next;
   current->next = new;
   return i;
@@ -85,7 +86,8 @@ ll_remove(struct LinkedList* list)
 
   list->head = n->next;
   list->size--;
-  return n->data;
+
+  return node_free(n);
 }
 
 int

--- a/src/main.c
+++ b/src/main.c
@@ -275,14 +275,13 @@ main(int argc, char** argv)
     // Expand aliases in info commands.
     for (int i = 0; i <= info->pipeNum; i++) {
       struct Command* const cmd = &info->CommArray[i];
-      char* expansion;
+      char* expansion = NULL;
       if (alias_exp(cmd->command, &expansion) <= 0) {
         continue;
       }
 
       // replace command with alias expansion
-      free(cmd->command);
-      cmd->command = expansion;
+      strcpy(cmd->command, expansion);
     }
 
 #ifndef NDEBUG
@@ -291,7 +290,7 @@ main(int argc, char** argv)
 
     // com contains the info. of the command before the first "|"
     const struct Command* cmd = &info->CommArray[0];
-    if (!cmd || !cmd->command) {
+    if (!cmd || cmd->command[0] == '\0') {
       free_info(info);
       continue;
     }

--- a/src/parse.c
+++ b/src/parse.c
@@ -23,6 +23,7 @@ void
 free_command(const struct Command* command)
 {
   if (!command) return;
+
   for (int i = 0; i < command->VarNum; i++) {
     free(command->VarList[i]);
   }
@@ -123,6 +124,7 @@ parse(const char* cmdline)
           free(arg);
           goto error;
         }
+
         cmd.VarList[cmd.VarNum] = arg;
         cmd.VarNum++;
       }

--- a/src/parse.c
+++ b/src/parse.c
@@ -19,6 +19,14 @@
 size_t
 copy_substring(char*, const char*, int, int);
 
+void free_command(const struct Command* command) {
+  if (!command) return;
+  free(command->command);
+  for (int i = 0; i < command->VarNum; i++) {
+    free(command->VarList[i]);
+  }
+}
+
 void
 init_info(struct ParseInfo* p)
 {
@@ -125,6 +133,7 @@ parse(const char* cmdline)
   return result;
 
 error:
+  free_command(&cmd);
   free_info(result);
   return NULL;
 }
@@ -140,8 +149,10 @@ copy_substring(char* dest, const char* src, const int begin, const int limit)
   int end = begin;
   for (; !isspace(src[end]) && src[end] != '\n' && src[end] != '\0'; end++)
     ;
+
   if (end - begin > limit)
     return SIZE_MAX;  // length of string to copy too large
+
   strncpy(dest, src + begin, end - begin);
   dest[end] = '\0';
   return end - 1;
@@ -177,12 +188,9 @@ free_info(const struct ParseInfo* info)
 {
   if (!info) return;
 
-  for (int i = 0; i < info->pipeNum; i++) {
-    const struct Command cmd = info->CommArray[i];
-    if (cmd.command) free(cmd.command);
-    for (int i = 0; i < cmd.VarNum; i++) {
-      if (cmd.VarList[i]) free(cmd.VarList[i]);
-    }
+  for (int i = 0; i <= info->pipeNum; i++) {
+    free_command(&(info->CommArray[i]));
   }
+
   free((void*)info);
 }

--- a/src/parse.c
+++ b/src/parse.c
@@ -7,117 +7,126 @@
 
 #include "parse.h"
 
+#include <err.h>
 #include <ctype.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sysexits.h>
 
 /* Function prototypes. */
-int copy_substring(char*, const char*, const int, const int);
+size_t
+copy_substring(char*, const char*, int, int);
 
 void
 init_info(struct ParseInfo* p)
 {
-  *p = (struct ParseInfo){.hasInputRedirection = false,
-                          .hasOutputRedirection = false,
-                          .runInBackground = false,
-                          .pipeNum = 0,
-                          .inFile = "",
-                          .outFile = "" };
-}
-
-void
-init_command(struct Command* p)
-{
-  *p = (struct Command){.command = malloc(MAXLINE * sizeof(char)),
-                        .VarList = { NULL },
-                        .VarNum = 0 };
+  *p = (struct ParseInfo){ .hasInputRedirection = false,
+                           .hasOutputRedirection = false,
+                           .runInBackground = false,
+                           .pipeNum = 0,
+                           .inFile = "",
+                           .outFile = "" };
 }
 
 struct ParseInfo*
 parse(const char* cmdline)
 {
-  // Ensure string is nonempty.
-  if (cmdline[0] == '\0') return NULL;
+  const size_t cmdline_len = strlen(cmdline);
+
+  // Ensure cmdline is nonempty
+  if (cmdline_len == 0) return NULL;
 
   // Skip blank characters at the start of the cmdline
-  int i = 0;
-  for (; isspace(cmdline[i]) && cmdline[i] != '\n' && cmdline[i] != '\0'; i++)
+  size_t i = 0;
+  for (; i < cmdline_len && isspace(cmdline[i]) && cmdline[i] != '\n'; i++)
     ;
 
   // After removing blanks, is the string now empty?
-  if (cmdline[i] == '\n' || cmdline[i] == '\0') return NULL;
+  if (i == cmdline_len || cmdline[i] == '\n') return NULL;
 
-  struct ParseInfo* Result = malloc(sizeof(struct ParseInfo));
-  init_info(Result);
+  struct ParseInfo* result = malloc(sizeof(struct ParseInfo));
+  if (!result) goto error;
+  init_info(result);
 
-  struct Command* cmd = malloc(sizeof(struct Command));
-  init_command(cmd);
-  for (; cmdline[i] != '\n' && cmdline[i] != '\0'; i++) {
+  struct Command cmd = { .command = NULL,
+                         .VarList = { NULL },
+                         .VarNum = 0 };
+
+  for (; i < cmdline_len && cmdline[i] != '\n'; i++) {
     // command1 < infile | command > outfile &
     if (isspace(cmdline[i])) continue;
 
-    if (cmd->command[0] == '\0') {
-      i = copy_substring(cmd->command, cmdline, i, MAXLINE);
-      if (i == -1) {
-        fprintf(stderr, "Error. The command exceeds the %d character limit.\n",
+    if (!cmd.command) {
+      cmd.command = malloc(MAXLINE * sizeof(char));
+      if (!cmd.command) goto error;
+
+      i = copy_substring(cmd.command, cmdline, i, MAXLINE);
+      if (i == SIZE_MAX) {
+        fprintf(stderr,
+                "Error. The command exceeds the %d character limit.\n",
                 MAXLINE);
-        free(cmd);
-        free_info(Result);
-        return NULL;
+        goto error;
       }
-    } else if (Result->hasInputRedirection && Result->inFile[0] == '\0') {
-      i = copy_substring(Result->inFile, cmdline, i, FILE_MAX_SIZE);
-      if (i == -1) {
+    } else if (result->hasInputRedirection && result->inFile[0] == '\0') {
+      i = copy_substring(result->inFile, cmdline, i, FILE_MAX_SIZE);
+      if (i == SIZE_MAX) {
         fprintf(stderr,
                 "Error. The input redirection filename exceeds the "
                 "%d character limit.\n",
                 FILE_MAX_SIZE);
-        free_info(Result);
-        return NULL;
+        goto error;
       }
-    } else if (Result->hasOutputRedirection && Result->outFile[0] == '\0') {
-      i = copy_substring(Result->outFile, cmdline, i, FILE_MAX_SIZE);
-      if (i == -1) {
+    } else if (result->hasOutputRedirection && result->outFile[0] == '\0') {
+      i = copy_substring(result->outFile, cmdline, i, FILE_MAX_SIZE);
+      if (i == SIZE_MAX) {
         fprintf(stderr,
                 "Error. The output redirection filename exceeds the "
                 "%d character limit.\n",
                 FILE_MAX_SIZE);
-        free_info(Result);
-        return NULL;
+        goto error;
       }
     } else {
       if (cmdline[i] == '<') {
-        Result->hasInputRedirection = true;
+        result->hasInputRedirection = true;
       } else if (cmdline[i] == '>') {
-        Result->hasOutputRedirection = true;
+        result->hasOutputRedirection = true;
       } else if (cmdline[i] == '&') {
-        Result->runInBackground = true;
+        result->runInBackground = true;
         break;  // '&' should be the last character
       } else if (cmdline[i] == '|') {
-        Result->CommArray[Result->pipeNum] = *cmd;
-        Result->pipeNum++;
-        cmd = malloc(sizeof(struct Command));
-        init_command(cmd);
+        result->CommArray[result->pipeNum] = cmd;
+        result->pipeNum++;
+
+        // Reset cmd
+        cmd.command = NULL;
+        memset(cmd.VarList, 0, sizeof(cmd.VarList));
+        cmd.VarNum = 0;
       } else if (!isspace(cmdline[i])) {
         char* arg = malloc(MAXLINE * sizeof(char));
+        if (!arg) goto error;
+
         i = copy_substring(arg, cmdline, i, MAXLINE);
-        if (i == -1) {
+        if (i == SIZE_MAX) {
           fprintf(stderr,
                   "Error. The variable exceeds the %d character limit.\n",
                   MAXLINE);
-          free_info(Result);
-          return NULL;
+          free(arg);
+          goto error;
         }
-        cmd->VarList[cmd->VarNum] = arg;
-        cmd->VarNum++;
+        cmd.VarList[cmd.VarNum] = arg;
+        cmd.VarNum++;
       }
     }
   }
-  Result->CommArray[Result->pipeNum] = *cmd;
-  free(cmd);
 
-  return Result;
+  result->CommArray[result->pipeNum] = cmd;
+  return result;
+
+error:
+  free_info(result);
+  return NULL;
 }
 
 /**
@@ -125,13 +134,14 @@ parse(const char* cmdline)
  * is encountered. Returns the index of the last valid character found. Returns
  * -1 if the length of the new string is greater than the supplied limit.
  */
-int
+size_t
 copy_substring(char* dest, const char* src, const int begin, const int limit)
 {
   int end = begin;
   for (; !isspace(src[end]) && src[end] != '\n' && src[end] != '\0'; end++)
     ;
-  if (end - begin > limit) return -1;  // length of string to copy too large
+  if (end - begin > limit)
+    return SIZE_MAX;  // length of string to copy too large
   strncpy(dest, src + begin, end - begin);
   dest[end] = '\0';
   return end - 1;

--- a/src/parse.h
+++ b/src/parse.h
@@ -1,5 +1,6 @@
 #ifndef PARSE_H
 #define PARSE_H
+
 #include <stdbool.h>
 
 #define MAXLINE 81

--- a/src/parse.h
+++ b/src/parse.h
@@ -10,7 +10,7 @@
 
 struct Command
 {
-  char* command;
+  char command[MAXLINE];
   char* VarList[MAX_VAR_NUM];
   int VarNum;
 };
@@ -28,9 +28,12 @@ struct ParseInfo
 };
 
 /* Function prototypes. */
-struct ParseInfo* parse(const char*);
+struct ParseInfo*
+parse(const char*);
 
-void free_info(const struct ParseInfo*);
+void
+free_info(const struct ParseInfo*);
 
-void print_info(const struct ParseInfo*);
+void
+print_info(const struct ParseInfo*);
 #endif

--- a/tests/test_bsh_alias.c
+++ b/tests/test_bsh_alias.c
@@ -1,7 +1,9 @@
-#include "../src/alias.h"
+#include "alias.h"
 
 #include <check.h>
 #include <stdlib.h>
+
+#include "test_utils.h"
 
 void
 alias_setup()
@@ -11,7 +13,9 @@ alias_setup()
 
 void
 alias_teardown()
-{}
+{
+  aliases_deinit();
+}
 
 START_TEST(test_alias_add_expand)
 {
@@ -21,6 +25,8 @@ START_TEST(test_alias_add_expand)
   char* expansion;
   ck_assert_int_eq(alias_exp("bob", &expansion), 1);
   ck_assert_str_eq(expansion, "echo");
+
+  unalias_all();
   free(expansion);
 }
 END_TEST
@@ -35,17 +41,20 @@ START_TEST(test_alias_print_several)
 
   char* argv_print[] = { "alias", "bob", "harry" };
   ck_assert_int_eq(alias(3, argv_print), 0);
+
+  unalias_all();
 }
 END_TEST
 
 START_TEST(test_alias_print_some_do_not_exist)
 {
-
   char* argv[] = { "alias", "bob=echo" };
   ck_assert_int_eq(alias(2, argv), 0);
 
   char* argv_print[] = { "alias", "bob", "harry" };
   ck_assert_int_ne(alias(3, argv_print), 0);
+
+  unalias_all();
 }
 END_TEST
 
@@ -59,6 +68,8 @@ START_TEST(test_alias_print_all)
 
   char* argv_print[] = { "alias" };
   ck_assert_int_eq(alias(1, argv_print), 0);
+
+  unalias_all();
 }
 END_TEST
 
@@ -80,6 +91,8 @@ START_TEST(test_unalias_exists)
   char* expansion;
   alias_exp("bob", &expansion);
   ck_assert(!expansion);
+
+  unalias_all();
 }
 END_TEST
 
@@ -108,6 +121,8 @@ START_TEST(test_unalias_remove_all)
   char* expanded = NULL;
   ck_assert_int_eq(alias_exp("bob", &expanded), 0);
   ck_assert_int_eq(alias_exp("harry", &expanded), 0);
+
+  unalias_all();
 }
 END_TEST
 
@@ -115,7 +130,7 @@ START_TEST(test_alias_expand_does_not_exist)
 {
   char* expansion = NULL;
   ck_assert_int_eq(alias_exp("alias", &expansion), 0);
-  ck_assert(!expansion);
+  bsh_assert_ptr_null(expansion);
 }
 END_TEST
 

--- a/tests/test_bsh_alias.c
+++ b/tests/test_bsh_alias.c
@@ -11,8 +11,7 @@ alias_setup()
 
 void
 alias_teardown()
-{
-}
+{}
 
 START_TEST(test_alias_add_expand)
 {
@@ -93,14 +92,22 @@ END_TEST
 
 START_TEST(test_unalias_remove_all)
 {
+  // Arrange
   char* argv_alias[] = { "alias", "bob=echo" };
   ck_assert_int_eq(alias(2, argv_alias), 0);
 
   char* argv_alias2[] = { "alias", "harry=echo" };
   ck_assert_int_eq(alias(2, argv_alias2), 0);
 
+  // Act
   char* argv[] = { "unalias", "-a" };
-  ck_assert_int_eq(unalias(2, argv), 0);
+  const int unalias_result = unalias(2, argv);
+
+  // Assert
+  ck_assert_int_eq(unalias_result, c_bsh_alias_error_success);
+  char* expanded = NULL;
+  ck_assert_int_eq(alias_exp("bob", &expanded), 0);
+  ck_assert_int_eq(alias_exp("harry", &expanded), 0);
 }
 END_TEST
 

--- a/tests/test_bsh_circular_queue.c
+++ b/tests/test_bsh_circular_queue.c
@@ -187,6 +187,7 @@ END_TEST
 START_TEST(test_cq_increase_capacity_correct_slots)
 {
   circular_queue* queue = circular_queue_init(1);
+
   bsh_assert_ptr_not_null(queue);
   bsh_assert_ptr_null(circular_queue_push(queue, "elem0"));
   bsh_assert_ptr_not_null(circular_queue_push(queue, "elem1"));
@@ -194,6 +195,8 @@ START_TEST(test_cq_increase_capacity_correct_slots)
   ck_assert_str_eq(queue->entries[1], "elem1");
   bsh_assert_ptr_null(queue->entries[0]);
   bsh_assert_ptr_null(queue->entries[2]);
+
+  circular_queue_free(queue, NULL); 
 }
 END_TEST
 

--- a/tests/test_bsh_circular_queue.c
+++ b/tests/test_bsh_circular_queue.c
@@ -31,7 +31,7 @@ START_TEST(test_cq_push_one)
 }
 END_TEST
 
-START_TEST(test_cq_push_above_capacity)
+START_TEST(test_cq_push_above_capacity_when_capacity_is_one)
 {
   // 1 capacity: push is in-place swap
   circular_queue* queue1 = circular_queue_init(1);
@@ -46,7 +46,11 @@ START_TEST(test_cq_push_above_capacity)
   retval = circular_queue_get(queue1, 1);
   ck_assert_ptr_eq(retval, another_elem);
   circular_queue_free(queue1, NULL);
+}
+END_TEST
 
+START_TEST(test_cq_push_above_capacity_when_capacity_is_two)
+{
   // 2 capacity: simple to reason about
   circular_queue* queue2 = circular_queue_init(2);
   bsh_assert_ptr_not_null(queue2);
@@ -59,19 +63,26 @@ START_TEST(test_cq_push_above_capacity)
   bsh_assert_ptr_not_null(circular_queue_get(queue2, 1));
   bsh_assert_ptr_not_null(circular_queue_get(queue2, 2));
   circular_queue_free(queue2, NULL);
+}
+END_TEST
 
-  // N capacity: normal case
+START_TEST(test_cq_push_above_capacity_when_capacity_is_n)
+{
   const size_t capacity = 10;
   const size_t elems_to_add = 100;
+
   circular_queue* norm = circular_queue_init(capacity);
   bsh_assert_ptr_not_null(norm);
+
   for (size_t i = 0; i < elems_to_add; i++) {
     char* dyn_elem = NULL;
     ck_assert_int_ge(asprintf(&dyn_elem, "e%zu", i), 0);
     char* old = circular_queue_push(norm, dyn_elem);
-    if (i > capacity) {
+    if (i >= capacity) {
       bsh_assert_ptr_not_null(old);
       free(old);
+    } else {
+      ck_assert_ptr_null(old);
     }
   }
 
@@ -283,7 +294,9 @@ make_circular_queue_suite()
 
   tcase_add_test(tc, test_cq_init_free);
   tcase_add_test(tc, test_cq_push_one);
-  tcase_add_test(tc, test_cq_push_above_capacity);
+  tcase_add_test(tc, test_cq_push_above_capacity_when_capacity_is_one);
+  tcase_add_test(tc, test_cq_push_above_capacity_when_capacity_is_two);
+  tcase_add_test(tc, test_cq_push_above_capacity_when_capacity_is_n);
   tcase_add_test(tc, test_cq_get);
   tcase_add_test(tc, test_cq_increase_capacity);
   tcase_add_test(tc, test_cq_increase_capacity_correct_slots);

--- a/tests/test_bsh_history.c
+++ b/tests/test_bsh_history.c
@@ -30,6 +30,7 @@ START_TEST(test_history_add)
   char* actual = NULL;
   ck_assert_int_eq(history_exp("!1", &actual), 1);
   ck_assert_str_eq(actual, "command");
+  free(actual);
 }
 END_TEST
 

--- a/tests/test_bsh_job.c
+++ b/tests/test_bsh_job.c
@@ -3,34 +3,25 @@
 #include <stdlib.h>
 #include <termios.h>
 
-#include "parse.h"
 #include "check.h"
+#include "parse.h"
 
 #include "test_utils.h"
 
 struct termios tmodes;
-job* j;
-struct ParseInfo* p;
-
-void
-job_setup(void)
-{
-  j = malloc(sizeof(job));
-}
-
-void
-job_teardown(void)
-{
-  free(j);
-  free(p);
-}
 
 START_TEST(test_job_init)
 {
-  p = parse("command1 var1 | command2 var2");
-  init_job(j, p, 0, tmodes);
-  ck_assert(!j->next);
-  ck_assert_int_eq(j->first_process->argc, 2);
+  struct ParseInfo* p = parse("command1 var1 | command2 var2");
+  bsh_assert_ptr_not_null(p);
+
+  struct job j;
+  init_job(&j, p, 0, tmodes);
+
+  bsh_assert_ptr_null(j.next);
+  ck_assert_int_eq(j.first_process->argc, 2);
+
+  free(p);
 }
 END_TEST
 
@@ -43,9 +34,9 @@ make_job_suite(void)
   TCase* tc = tcase_create("Core");
 
   suite_add_tcase(s, tc);
-  tcase_add_checked_fixture(tc, job_setup, job_teardown);
 
-  BSH_TEST_ADD_TEST_DISABLED_ON_LINUX(tc, test_job_init, "https://github.com/rgardner/bsh/issues/16");
+  BSH_TEST_ADD_TEST_DISABLED_ON_LINUX(
+    tc, test_job_init, "https://github.com/rgardner/bsh/issues/16");
 
   return s;
 }

--- a/tests/test_bsh_job.c
+++ b/tests/test_bsh_job.c
@@ -15,13 +15,15 @@ START_TEST(test_job_init)
   struct ParseInfo* p = parse("command1 var1 | command2 var2");
   bsh_assert_ptr_not_null(p);
 
-  struct job j;
-  init_job(&j, p, 0, tmodes);
+  struct job* j = malloc(sizeof(struct job));
+  init_job(j, p, 0, tmodes);
 
-  bsh_assert_ptr_null(j.next);
-  ck_assert_int_eq(j.first_process->argc, 2);
+  bsh_assert_ptr_null(j->next);
+  ck_assert_int_eq(j->first_process->argc, 2);
 
-  free(p);
+  job_free(j);
+  free(j);
+  free_info(p);
 }
 END_TEST
 
@@ -35,8 +37,7 @@ make_job_suite(void)
 
   suite_add_tcase(s, tc);
 
-  BSH_TEST_ADD_TEST_DISABLED_ON_LINUX(
-    tc, test_job_init, "https://github.com/rgardner/bsh/issues/16");
+  tcase_add_test(tc, test_job_init);
 
   return s;
 }

--- a/tests/test_bsh_parse.c
+++ b/tests/test_bsh_parse.c
@@ -12,13 +12,11 @@
 
 void
 parse_setup(void)
-{
-}
+{}
 
 void
 parse_teardown(void)
-{
-}
+{}
 
 START_TEST(test_parse_empty)
 {
@@ -49,7 +47,7 @@ END_TEST
 
 START_TEST(test_parse_files_too_long)
 {
-  char file[FILE_MAX_SIZE + 2]; // max_size, one char past, NULL
+  char file[FILE_MAX_SIZE + 2];  // max_size, one char past, NULL
   for (int i = 0; i < BSH_ARRAY_SSIZE(file); i++) {
     file[i] = 'x';
   }
@@ -66,6 +64,7 @@ END_TEST
 START_TEST(test_parse_normal)
 {
   struct ParseInfo* p = parse("command");
+  bsh_assert_ptr_not_null(p);
   ck_assert(p->hasInputRedirection == false);
   ck_assert(p->hasOutputRedirection == false);
   ck_assert(p->runInBackground == false);
@@ -73,43 +72,52 @@ START_TEST(test_parse_normal)
   ck_assert_int_eq(p->pipeNum, 0);
   ck_assert_str_eq(p->inFile, "");
   ck_assert_str_eq(p->outFile, "");
+  free_info(p);
 }
 END_TEST
 
 START_TEST(test_parse_file_redirection)
 {
   struct ParseInfo* p = parse("echo <infile >outfile");
+  bsh_assert_ptr_not_null(p);
   ck_assert(p->hasInputRedirection);
   ck_assert(p->hasOutputRedirection);
   ck_assert_str_eq(p->inFile, "infile");
   ck_assert_str_eq(p->outFile, "outfile");
+  free_info(p);
 }
 END_TEST
 
 START_TEST(test_parse_background)
 {
   struct ParseInfo* p = parse("long_running_task &");
+  bsh_assert_ptr_not_null(p);
   ck_assert(p->runInBackground);
+  free_info(p);
 }
 END_TEST
 
 START_TEST(test_parse_piping)
 {
   struct ParseInfo* p = parse("command1 | command2 | command3");
+  bsh_assert_ptr_not_null(p);
   ck_assert_int_eq(p->pipeNum, 2);
   ck_assert_str_eq(p->CommArray[0].command, "command1");
   ck_assert_str_eq(p->CommArray[1].command, "command2");
   ck_assert_str_eq(p->CommArray[2].command, "command3");
+  free_info(p);
 }
 END_TEST
 
 START_TEST(test_parse_variables)
 {
   struct ParseInfo* p = parse("command var1 var2 var3");
+  bsh_assert_ptr_not_null(p);
   ck_assert_int_eq(p->CommArray[0].VarNum, 3);
   ck_assert_str_eq(p->CommArray[0].VarList[0], "var1");
   ck_assert_str_eq(p->CommArray[0].VarList[1], "var2");
   ck_assert_str_eq(p->CommArray[0].VarList[2], "var3");
+  free_info(p);
 }
 END_TEST
 
@@ -141,11 +149,14 @@ make_parse_suite(void)
   tcase_add_test(tc, test_parse_blanks);
   tcase_add_test(tc, test_parse_command_too_long);
   tcase_add_test(tc, test_parse_files_too_long);
-  BSH_TEST_ADD_TEST_DISABLED_ON_LINUX(tc, test_parse_normal, "https://github.com/rgardner/bsh/issues/16");
+  BSH_TEST_ADD_TEST_DISABLED_ON_LINUX(
+    tc, test_parse_normal, "https://github.com/rgardner/bsh/issues/16");
   tcase_add_test(tc, test_parse_file_redirection);
   tcase_add_test(tc, test_parse_background);
-  BSH_TEST_ADD_TEST_DISABLED_ON_LINUX(tc, test_parse_piping, "https://github.com/rgardner/bsh/issues/16");
-  BSH_TEST_ADD_TEST_DISABLED_ON_LINUX(tc, test_parse_variables, "https://github.com/rgardner/bsh/issues/16");
+  BSH_TEST_ADD_TEST_DISABLED_ON_LINUX(
+    tc, test_parse_piping, "https://github.com/rgardner/bsh/issues/16");
+  BSH_TEST_ADD_TEST_DISABLED_ON_LINUX(
+    tc, test_parse_variables, "https://github.com/rgardner/bsh/issues/16");
   tcase_add_test(tc, test_parse_free_null);
   tcase_add_test(tc, test_parse_print_null);
 

--- a/tests/test_bsh_parse.c
+++ b/tests/test_bsh_parse.c
@@ -149,14 +149,11 @@ make_parse_suite(void)
   tcase_add_test(tc, test_parse_blanks);
   tcase_add_test(tc, test_parse_command_too_long);
   tcase_add_test(tc, test_parse_files_too_long);
-  BSH_TEST_ADD_TEST_DISABLED_ON_LINUX(
-    tc, test_parse_normal, "https://github.com/rgardner/bsh/issues/16");
+  tcase_add_test(tc, test_parse_normal);
   tcase_add_test(tc, test_parse_file_redirection);
   tcase_add_test(tc, test_parse_background);
-  BSH_TEST_ADD_TEST_DISABLED_ON_LINUX(
-    tc, test_parse_piping, "https://github.com/rgardner/bsh/issues/16");
-  BSH_TEST_ADD_TEST_DISABLED_ON_LINUX(
-    tc, test_parse_variables, "https://github.com/rgardner/bsh/issues/16");
+  tcase_add_test(tc, test_parse_piping);
+  tcase_add_test(tc, test_parse_variables);
   tcase_add_test(tc, test_parse_free_null);
   tcase_add_test(tc, test_parse_print_null);
 

--- a/tests/test_bsh_parse.c
+++ b/tests/test_bsh_parse.c
@@ -41,7 +41,7 @@ START_TEST(test_parse_command_too_long)
   command[BSH_ARRAY_SIZE(command) - 1] = '\0';
 
   struct ParseInfo* p = parse(command);
-  ck_assert(p == NULL);
+  bsh_assert_ptr_null(p);
 }
 END_TEST
 

--- a/tests/test_bsh_stack.c
+++ b/tests/test_bsh_stack.c
@@ -1,7 +1,10 @@
-#include "../src/stack.h"
-#include "test_bsh.h"
+#include "stack.h"
+
 #include <check.h>
 #include <stdlib.h>
+
+#include "test_bsh.h"
+#include "test_utils.h"
 
 static char data[1024] = "element 1";
 static struct Stack* s;
@@ -27,9 +30,12 @@ END_TEST
 START_TEST(test_push_normal)
 {
   char* elem = strndup(data, sizeof(char) * strlen(data));
+  bsh_assert_ptr_not_null(elem);
+
   stack_push(s, elem);
   ck_assert_msg(stack_peak(s) == elem,
                 "element should be on the top of the stack");
+
   free(elem);
 }
 END_TEST
@@ -37,9 +43,12 @@ END_TEST
 START_TEST(test_pop_normal)
 {
   char* elem = strndup(data, strlen(data));
+  bsh_assert_ptr_not_null(elem);
+
   stack_push(s, elem);
   char* other = stack_pop(s);
   ck_assert_msg(elem == other, "pop should remove an element");
+
   free(elem);
 }
 END_TEST

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -3,12 +3,6 @@
 
 #include <check.h>
 
-#ifdef __linux__
-#define BSH_TEST_ADD_TEST_DISABLED_ON_LINUX(tc, test, message) (void)(tc), (void)(test), (void)(message)
-#else
-#define BSH_TEST_ADD_TEST_DISABLED_ON_LINUX(tc, test, message) tcase_add_test(tc, test); (void)(message)
-#endif
-
 #ifdef ck_assert_ptr_null
 #define bsh_assert_ptr_null(expr) ck_assert_ptr_null(expr)
 #else


### PR DESCRIPTION
- adds optional valgrind support
- adds Dockerfile for Linux development
- fixes UB and memory issues in parse and job code. There were a few classes of issues:
   + not freeing everything in the `*free*` functions
   + using `malloc` instead of `calloc` which breaks strcmp (strncmp is better, but check uses strcmp)
   + lots of missing `frees` in error handling and test code

Fixes #16 